### PR TITLE
Add mcp-go-x402 Go MCP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [thirdweb/x402 (Github)](https://github.com/thirdweb-dev/js/tree/main/packages/thirdweb/src/x402)
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
+- [mcp-go-x402 (Go MCP SDK for x402)](https://github.com/mark3labs/mcp-go-x402)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 


### PR DESCRIPTION
## Summary
- Add mcp-go-x402, a Go MCP SDK for building x402-enabled Model Context Protocol servers