### PR TITLE
feat: remove suspicious x402 discord community link which has fake collab.land verification bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Community
 - [Reddit – r/x402](https://www.reddit.com/r/x402/)
 - [Discord – Coinbase Developer Platform](https://discord.com/invite/cdp)
-- [x402 Discord Community](https://discord.gg/x402)
 
 ### Contributing
 - Add high-signal links: specifications, reference implementations, deep-dive posts, audits, and example apps.


### PR DESCRIPTION
Removed x402 Discord Community link from README as it has fake collab.land verification bot.

<img width="2772" height="1956" alt="CleanShot_2025-11-04_19-25-21@2x" src="https://github.com/user-attachments/assets/79c51c3d-c8c9-4789-aaf1-33f2d7b1445c" />
