### PR TITLE
Add x402X extension to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 #### Extensions
 - [ERC-3009 Forwarding](https://github.com/TheGreatAxios/eip3009-forwarder): forwarding contract extending meta-transactions with EIP-721 signatures to any ERC-20 on any network
+- [x402X Protocol](https://www.x402x.dev/): an extension protocol to x402, enabling an arbitrary contract call with an x402 payment. 
 
 ### Tutorials & Guides
 - [QuickNode – How to Implement a Crypto Paywall with x402](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)


### PR DESCRIPTION
Hi Merit magicians,

Thanks for creating the repo.

We are working on the x402X (full name x402-exec), which is an extension protocol that enables an x402 payment to trigger arbitrary on-chain contract calls.
We believe this will open up more possibilities for the protocol such as: 
1. split the payment
2. mint token/nft with a payment
3. token swap pre/post the payment

 Our current approach is based on a patched x402 package but based on [the discussion here](https://github.com/coinbase/x402/pull/578), we will be officially relying on the x402 official v2 package.

Relevant links:
- website: https://www.x402x.dev/
- Github Repo: https://github.com/nuwa-protocol/x402-exec