### PR TITLE
Add x402-agent-pay to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
+- [x402-agent-pay (Agent payments with MCP, spending controls, discovery & receipts)](https://github.com/Omnivalent/x402-agent-pay)
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol


### PR DESCRIPTION
## x402-agent-pay

Agent-first x402 payment client with unique combination of features:

**MCP Server** — 5 tools for Claude/GPT integration (pay, discover, balance, status, history)
**Spending Controls** — Per-tx limits, daily velocity, whitelist/blacklist domains
**Service Discovery** — Find x402 APIs programmatically by category, network, or price
**Receipt Audit Trail** — Cryptographic receipts for every payment
**Built on official SDK** — Uses @x402/fetch, not custom implementation

### Links
- **GitHub**: https://github.com/Omnivalent/x402-agent-pay
- **Release**: https://github.com/Omnivalent/x402-agent-pay/releases/tag/v2.2.0
- **Live testnet proof**: https://sepolia.basescan.org/tx/0x51c7440999aebc9419ebb51a448e3f26f2f95d5e2f7b002b80c434e940d938a5

32 tests passing. Created for the Moltbook USDC Hackathon (Feb 2026).