### PR TITLE
Add dTelecom STT — real-time speech-to-text service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [dTelecom STT](https://x402stt.dtelecom.org) - Real-time speech-to-text API for AI agents. 99+ languages, dual-engine (Parakeet + Whisper), $0.005/min. [Python SDK](https://github.com/dTelecom/stt-client-python) | [TypeScript SDK](https://github.com/dTelecom/stt-client-ts)
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)


### PR DESCRIPTION
Add dTelecom STT to Ecosystem section.

Real-time speech-to-text API for AI agents via x402 micropayments. Dual-engine (Parakeet-TDT + Whisper), 99+ languages, $0.005/min.

- **URL:** https://x402stt.dtelecom.org
- **Python SDK:** https://github.com/dTelecom/stt-client-python
- **TypeScript SDK:** https://github.com/dTelecom/stt-client-ts