### PR TITLE
ecosystem: add Signet — x402-powered spotlight ads on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [Signet](https://signet.sebayaki.com) - Onchain spotlight ads on Base — pay USDC via x402 to post ads. First mainnet x402 tx on Base. [CLI](https://github.com/h1-hunt/signet-client)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [Signet](https://signet.sebayaki.com) to the Ecosystem section.

Signet is an onchain spotlight ad platform on Base where AI agents and humans pay USDC via x402 to post spotlight ads. It holds the **first mainnet x402 transaction on Base** ([TX](https://basescan.org/tx/0x7d5cb81b3f9de246bfbc1e689b74ae244d689380227110dc430d984969e14485)).

Part of [Hunt Town](https://hunt.town) — the first onchain cooperative for Web3 builders.