### PR TITLE
Add x402 Dynamic Pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [x402 Dynamic Pricing](https://github.com/trionlabs/x402-dynamic-pricing) - Demand-based surge pricing engine for x402 V2 with sliding window, 5-tier interpolation, EMA smoothing, and interactive Svelte 5 simulator.
 
 
 ### Security & Ops


### PR DESCRIPTION
Add x402 Dynamic Pricing, a reference implementation of demand-based surge pricing using x402 V2's dynamic `getAmount` callback. Includes deployable Express server, standalone pricing engine and a simulator.