### PR TITLE
Add MoonMaker API — x402 pay-per-call crypto intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Curated resources for the x402 ecosystem: specs, repos, standards, and community
 
 ### Quick Links
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - [Website](https://www.x402.org/)
 - [Spec / Repo](https://github.com/coinbase/x402)
 - [Explorer](https://x402scan.com/)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Curated resources for the x402 ecosystem: specs, repos, standards, and community. Contributions welcome via pull requests.
 
 ### Quick Links
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, regime, institutions, ETF flows, DeFi yields & DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - [Website](https://www.x402.org/)
 - [Spec / Repo](https://github.com/coinbase/x402)
 - [Explorer](https://x402scan.com/)


### PR DESCRIPTION
## Add MoonMaker API

[MoonMaker API](https://api.moonmaker.cc) is a live x402 pay-per-call crypto intelligence API built for AI agents.

- 11 endpoints: signals, context, regime, risk, institutions, ETF, yields, DEX alpha
- $0.02–$0.10 USDC per call on Base mainnet
- No signup or API key — pure x402
- AI agent discovery via [llms.txt](https://api.moonmaker.cc/llms.txt)
- Live since Feb 2026