### PR TITLE
Add agentpay-mcp — non-custodial x402 MCP payment server for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 
 
+- [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
 ### Standards and EIPs
 - [ERC-3009 — Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009): meta-transaction transfers using EIP-712 signatures, enabling gasless and recipient-submitted transfers.
 - [EIP-712 — Typed Structured Data Hashing and Signing](https://eips.ethereum.org/EIPS/eip-712): canonical typed signing used by modern wallets.


### PR DESCRIPTION
## What is this?

[agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp) is an open-source, non-custodial x402 MCP payment server for AI agents — the open-source alternative to Vercel x402-mcp.

## Key features
- **v1.2.0** — x402 V2 session payments (first non-custodial x402 V2 session implementation in MCP)
- Agents sign locally — no custodial infrastructure required
- Drop-in MCP server: works with Claude Desktop, Agent Zero, OpenClaw
- Built on Base Mainnet with USDC + CCTP cross-chain support
- 107/107 tests passing, MIT licensed

## Links
- npm: https://www.npmjs.com/package/agentpay-mcp
- GitHub: https://github.com/up2itnow0822/agentpay-mcp