### PR TITLE
Add DJD AgentScore – reputation scoring for x402 agent wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) — On-chain reputation scoring API for AI agent wallets. Returns a 0–100 trust score across 5 dimensions (identity, behavior, reliability, viability, capability) from x402 settlement history on Base. Free tier, no signup.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
## Summary

- Adds [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) to the **Ecosystem** section of the awesome list.
- DJD AgentScore is an on-chain reputation scoring API purpose-built for AI agent wallets. It analyzes x402 settlement history on Base and returns a 0–100 trust score across five dimensions: identity, behavior, reliability, viability, and capability.
- This is directly relevant to the x402 ecosystem because it gives sellers, facilitators, and other agents a standardized way to evaluate the trustworthiness of an AI agent wallet before accepting x402 payments — helping reduce fraud risk and enabling more autonomous agent-to-agent commerce.

## Why it belongs here

The x402 protocol enables AI agents to pay for services autonomously. As the ecosystem grows, reputation and trust signals become critical infrastructure. DJD AgentScore fills that gap by providing a free, no-signup API that scores agent wallets based on their actual on-chain x402 transaction behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)