### PR TITLE
Add x402 Service Discovery API — quality-scored discovery + MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
+- [x402 Service Discovery](https://x402-discovery-api.onrender.com) - Quality-scored service discovery for AI agents. Find x402-payable APIs by keyword/capability with uptime, latency, and health signals. MCP server (4 tools), 6 framework SDKs. $0.005 USDC/query on Base. [Demo](https://rplryan.github.io/ouroboros/demo.html)
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 
 ### Facilitators & Networks
@@ -46,6 +47,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
+- [x402-discovery-mcp](https://github.com/rplryan/x402-discovery-mcp) - MCP server for x402 service discovery. Quality-scored search across x402 ecosystem services with 4 tools: discover, browse, health, register. `pip install x402discovery`
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 


### PR DESCRIPTION
Adds two entries for the x402 Service Discovery API — a quality-scored runtime discovery service for AI agents that dogfoods the x402 protocol itself ($0.005 USDC/query on Base).

**Live service:** https://x402-discovery-api.onrender.com
**Demo:** https://rplryan.github.io/ouroboros/demo.html
**MCP:** https://smithery.ai/servers/rplryan/x402-discovery (4 tools)
**OSS:** https://github.com/rplryan/x402-discovery-mcp

- Quality signals: uptime %, latency, health status (not just a raw listing)
- 6 framework SDKs: LangChain, AutoGen, CrewAI, LlamaIndex, AgentKit, Python
- Added to Ecosystem and Open Source/SDKs sections