### PR TITLE
Add Kevros AI governance gateway and SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [Kevros Python SDK](https://pypi.org/project/kevros/) - AI governance client with x402 payment support and auto-provisioned API keys
+- [Kevros AgentKit (npm)](https://www.npmjs.com/package/@kevros/agentkit) - TypeScript ActionProvider for Coinbase AgentKit with x402 governance
 
 
 ### Standards and EIPs
@@ -79,6 +81,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Kevros Governance Gateway](https://governance.taskhawktech.com/docs) - AI governance API with five x402-paid endpoints: action verification, provenance attestation, intent binding, outcome verification, and compliance bundles. USDC on Base.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds Kevros to two sections:

**Open Source & SDKs:**
- [Kevros Python SDK](https://pypi.org/project/kevros/) — AI governance client with x402 payment support
- [Kevros AgentKit (npm)](https://www.npmjs.com/package/@kevros/agentkit) — TypeScript ActionProvider for Coinbase AgentKit

**Example Apps:**
- [Kevros Governance Gateway](https://governance.taskhawktech.com/docs) — Live x402-paid API with five governance endpoints (USDC on Base)

All four paid endpoints are registered on x402scan and return valid x402 V2 responses with Bazaar extensions.