### PR TITLE
Add agentwallet-sdk — TypeScript SDK with x402 payment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [agentwallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) - TypeScript SDK for non-custodial AI agent wallets. Handles x402 payments, CCTP V2 cross-chain transfers, Uniswap V3 token swaps, and on-chain spend limits. MIT license.
 
 
 ### Standards and EIPs


### PR DESCRIPTION
Adding [agentwallet-sdk](https://github.com/up2itnow0822/agent-wallet-sdk) to the list.

It's a TypeScript SDK for giving AI agents their own non-custodial wallets. Main features:

- x402 HTTP payment protocol support
- CCTP V2 cross-chain transfers (Circle's bridging protocol)  
- Uniswap V3 token swaps
- On-chain spend limits (agents can't go over budget)
- ERC-8004 agent identity support

MIT licensed, published on npm as `agentwallet-sdk`. Figured it fits well here given the focus on agent infrastructure/payments.
