### PR TITLE
Add x402charity — open-source micro-donation server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 MCP SDK Announcement](https://vercel.com/blog/introducing-x402-mcp-open-protocol-payments-for-mcp-tools)
 - [How to Get Started with x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) – Official Solana guide for integrating x402 payments on Solana networks.
 
+- [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
+
 ### Example Apps
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)


### PR DESCRIPTION
## What is x402charity?

[x402charity](https://x402charity.com) is an open-source micro-donation server powered by x402. It lets any company add automated USDC micro-donations to their product — a trade, an API call, or a game move can trigger a small donation to charity on Base.

**Key features:**
- Drop-in Express/Next.js middleware
- CLI tool (`npx x402charity donate`)
- Vercel-deployable server with built-in dashboard
- Sub-cent donations viable on Base L2

**Links:**
- Website: https://x402charity.com
- GitHub: https://github.com/allscale-io/x402charity
- npm: https://www.npmjs.com/package/x402charity

Added under the **Ecosystem** section.