### PR TITLE
Add Valoria — x402 market intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
+- [Valoria](https://x402.valoria.net) - x402 market intelligence — 90K+ services indexed, $46M+ tracked volume. Revenue rankings, service analysis, opportunity discovery, and pricing recommendations via x402 pay-per-call endpoints and MCP server.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 
 ### Facilitators & Networks


### PR DESCRIPTION
Adds [Valoria](https://x402.valoria.net) to the Ecosystem section alongside x402scan and x402station.

**What it does:** x402 market intelligence — indexes 90K+ services and $46M+ in on-chain volume across 30+ facilitators on Base and Solana. Revenue rankings, service analysis, opportunity discovery, and pricing recommendations.

**How it works:** 5 paid x402 endpoints ($1-$10), all pay-per-call with USDC on Base. Also available as an MCP server.

- npm: [@jamesrez/valoria](https://www.npmjs.com/package/@jamesrez/valoria)
- x402scan listing: [x402scan.com/server/972b0fd3](https://www.x402scan.com/server/972b0fd3-eeb7-4941-ae02-d24ecb3b60c7)