### PR TITLE
Add x402-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. `npx x402-proxy`.
 
 
 ### Standards and EIPs


### PR DESCRIPTION
Adds x402-proxy to the Open Source & SDKs section.

**x402-proxy** is `curl` for x402 paid APIs - a CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with an MCP stdio proxy for AI agents.

- [GitHub](https://github.com/cascade-protocol/x402-proxy)
- [npm](https://www.npmjs.com/package/x402-proxy)