### PR TITLE
Add PayCrow — escrow + trust layer for x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
+- [PayCrow](https://github.com/michu5696/paycrow) — Escrow protection for autonomous agent payments. Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution on Base. 10 MCP tools including safe_pay (trust-informed smart escrow) and trust_gate (go/no-go decision before payment). ([npm](https://www.npmjs.com/package/paycrow))
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 


### PR DESCRIPTION
## Summary

- Adds [PayCrow](https://github.com/michu5696/paycrow) to the **Open Source & SDKs** section
- PayCrow provides escrow protection for autonomous agent payments on Base
- Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution
- 10 MCP tools including `safe_pay` (trust-informed smart escrow) and `trust_gate` (go/no-go decision before payment)
- Published on npm as [`paycrow`](https://www.npmjs.com/package/paycrow)

## Why it belongs here

PayCrow is the trust and escrow layer for x402 — it wraps x402 payments with on-chain trust scoring and USDC escrow so autonomous agents can pay safely. Open source, on npm, and built specifically for the x402 ecosystem.