### PR TITLE
Add panevin-x402-api to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [panevin-x402-api](https://api.panevin.net) – Payment-gated web content extraction API (text, links, metadata, markdown) on Base mainnet. $0.001–$0.003 USDC per call. [Discovery](https://api.panevin.net/.well-known/x402)
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

- Adds [panevin-x402-api](https://api.panevin.net) to the **Example Apps** section
- Live payment-gated web content extraction API on Base mainnet (eip155:8453)
- Supports text, links, metadata, and markdown extraction
- Pricing: $0.001–$0.003 USDC per call
- x402 discovery endpoint: https://api.panevin.net/.well-known/x402

🤖 Generated with [Claude Code](https://claude.com/claude-code)