### PR TITLE
Add ATXP — agent identity and x402 payment infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [ATXP – Agent Identity & Payment Infrastructure](https://github.com/atxp-dev/atxp) – One command registers an AI agent with a USDC wallet on Base, `@atxp.email` inbox, and 100+ x402-paid MCP tools (web search, image gen, LLM). The agent is both an x402 payer and can receive USDC payments.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds [ATXP](https://github.com/atxp-dev/atxp) to the Example Apps section.

ATXP is a production x402 implementation from the agent-payer perspective: one CLI command gives an AI agent a USDC wallet on Base, registers it with the x402 payment rail, and unlocks 100+ paid MCP tools (web search, image gen, LLM gateway). The agent pays for every API call via USDC micropayments on Base — no custodian, no human in the loop.