### PR TITLE
Add EruditePay — 352 x402-payable blockchain analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
-- [EruditePay](https://bridge.eruditepay.com) - 352 x402-payable blockchain analytics endpoints (Base, Tron, BTC, XRP, Kaspa). 168 MCP tools for token prices, whale tracking, DeFi, gas, NFT, and security. Dual-network settlement: USDC on Base + USDT on Tron. Self-hosted facilitator.
+- [Erudite Intelligence x402 Services](https://services.eruditepay.com) - 11 x402 payment-gated API endpoints (crypto data, web scraping, smart contract auditing, domain intelligence) + 1000 Relic Drop Genesis NFT mint endpoints on Base Mainnet. USDC micropayments.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [EruditePay](https://bridge.eruditepay.com) - 352 x402-payable blockchain analytics endpoints (Base, Tron, BTC, XRP, Kaspa). 168 MCP tools for token prices, whale tracking, DeFi, gas, NFT, and security. Dual-network settlement: USDC on Base + USDT on Tron. Self-hosted facilitator.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Erudite Intelligence x402 services:

- **Services**: https://services.eruditepay.com
- **11 x402 endpoints**: crypto data, web scraping, smart contract auditing, domain intelligence
- **1000 NFT endpoints**: Relic Drop Genesis Collection (ERC-721 on Base Mainnet)
- **Payment**: USDC on Base (eip155:8453)
- **MCP server**: https://mcp.eruditepay.com (80 tools)
- **OpenAPI**: https://services.eruditepay.com/openapi.yaml