### PR TITLE
Add OpenVPS — AI-agent VPS hosting with x402 + MPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 MCP SDK Announcement](https://vercel.com/blog/introducing-x402-mcp-open-protocol-payments-for-mcp-tools)
 - [How to Get Started with x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) – Official Solana guide for integrating x402 payments on Solana networks.
 
+### Services & Live APIs
+- [OpenVPS](https://openvps.sh) – AI-agent VPS hosting. Pay with USDC on Base, Celo, or Tempo. Get root SSH access to Ubuntu 24.04 servers in seconds. Supports x402 + MPP. [Skill](https://openvps.sh/skill.md) | [OpenAPI](https://openvps.sh/openapi.json) | [GitHub](https://github.com/kartojal/openvps)
+
 ### Example Apps
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)


### PR DESCRIPTION
## Summary
- Added OpenVPS to a new Services & Live APIs section
- OpenVPS lets AI agents provision Ubuntu 24.04 VMs via HTTP 402 payments
- Supports x402 (Base USDC, Celo USDC) and MPP (Tempo USDC.e)
- Live at https://openvps.sh
- Already indexed on x402scan: https://www.x402scan.com/server/a7ad4651-cc49-4448-bbb7-b7cf18c29893

Links:
- [Skill file](https://openvps.sh/skill.md)
- [OpenAPI spec](https://openvps.sh/openapi.json)
- [x402 discovery](https://openvps.sh/.well-known/x402)
- [GitHub](https://github.com/kartojal/openvps)