### PR TITLE
Add x402 Wallet for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [x402 Wallet for Claude Desktop](https://github.com/402md/x402-wallet-for-claude-desktop) - Claude Desktop extension with x402 USDC payments on Stellar and Base. Automatic 402 handling with configurable spending limits.
 
 
 ### Standards and EIPs


### PR DESCRIPTION
## What
Adds x402 Wallet for Claude Desktop to the Open Source & SDKs section.

## Why
A Claude Desktop extension that enables x402 USDC payments on both **Stellar** and **Base** networks.

- **x402 native** — automatic HTTP 402 payment handling (sign and retry in a single call)
- **Multi-chain** — USDC on Stellar and Base (Coinbase L2)
- **Claude Desktop extension** — one-click .mcpb install
- **Budget safety** — configurable per-call and daily spending limits

## Checklist
- [x] Actively maintained
- [x] Clear documentation
- [x] MIT licensed
- [x] x402-specific