### PR TITLE
Add PreReason to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [PreReason](https://www.prereason.com) - Financial market context API with x402 pay-per-call. 17 pre-analyzed briefings (BTC, macro, cross-asset regime). $0.01-$0.03 USDC on Base. Dual facilitator support (Coinbase CDP + Dexter). ([GitHub](https://github.com/PreReason/mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds PreReason to the Ecosystem section.

PreReason is a financial data provider using x402 micropayments on Base ($0.01-$0.03 USDC per call). It serves 17 pre-analyzed market briefings with trend signals, regime classification, and confidence scores. Supports dual facilitators (Coinbase CDP + Dexter).

- Website: [prereason.com](https://www.prereason.com)
- GitHub: [PreReason/mcp](https://github.com/PreReason/mcp)