### PR TITLE
Add MERX - First x402 facilitator for TRON

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,6 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### License
 This list is offered under CC0; see upstream specs for their respective licenses.
+
+## TRON
+- [MERX x402 Facilitator](https://x402.merx.exchange) - First x402 facilitator for TRON. Supports USDT, USDC, USDD. Sub-3s confirmation for micropayments. [Express middleware](https://npmjs.com/package/merx-x402) | [Documentation](https://github.com/Hovsteder/x402-tron)


### PR DESCRIPTION
Adds MERX as the first TRON x402 facilitator.

- **URL:** https://x402.merx.exchange
- **Assets:** USDT, USDC, USDD on TRON mainnet
- **npm:** [merx-x402](https://npmjs.com/package/merx-x402)
- **Docs:** [github.com/Hovsteder/x402-tron](https://github.com/Hovsteder/x402-tron)
- **Mainnet TX:** https://tronscan.org/#/transaction/7a92e577b3f44faa97204983af3e74a71cac5a88732af54fca9c2464d9285ca4