### PR TITLE
Add SignalFuse to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Pinata jetson-x402 (Code)](https://github.com/PinataCloud/jetson-x402)
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
+- [SignalFuse Trading Intelligence API](https://signalfuse.co) - Production x402 signal API fusing social sentiment, macro regime, and Hyperliquid market structure into directional crypto signals. $0.01/call USDC on Base, live on mainnet via CDP facilitator. [GitHub](https://github.com/hypeprinter007-stack/signalfuse-mcp)
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
 
 


### PR DESCRIPTION
Adds SignalFuse — a production x402 trading signal API live on Base mainnet.

- Fuses social sentiment, macro regime, and Hyperliquid market structure into directional crypto signals
- $0.01/call USDC on Base via CDP facilitator
- Verified on mainnet: https://basescan.org/tx/aed006105b4467bcaffacf1ff094f062ddac8666855532328ea9cea02ad930f4
- Also supports credit tokens (25 free, no signup)
- MCP server, LangChain tool, ElizaOS plugin, and starter bot published

https://signalfuse.co