### PR TITLE
Add CryptoIZ - Solana DEX smart money signals via x402 MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [CryptoIZ](https://cryptoiz.org/McpLanding) - AI-powered Solana DEX smart money signals via MCP. Pay-per-call ($0.01–$0.05 USDC) for whale/dolphin accumulation, divergence, accumulation scoring, and BTC regime data. Solana mainnet via Dexter facilitator. [npm](https://www.npmjs.com/package/cryptoiz-mcp)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds CryptoIZ to the Ecosystem section.

**v4.16.0 UPDATE (Apr 24, 2026):**
- 9 tools total: 7 paid + 2 free
- Pricing: $0.01 – $0.05 per call
- NEW: `get_btc_futures_signal` ($0.03) — Multi-timeframe BTC futures scalping signal (4H regime + 5m entry)

Features:
- AI-powered Solana DEX whale intelligence
- MCP server for Claude Desktop (`npm install -g cryptoiz-mcp@4.16.0`)
- x402 V2 via Dexter facilitator, gas-sponsored
- Live on Solana mainnet with 66+ settlements
- MCP Registry: `io.github.dadang11/cryptoiz`

Links:
- https://cryptoiz.org/McpLanding
- https://www.npmjs.com/package/cryptoiz-mcp
- https://github.com/dadang11/cryptoiz-mcp