### PR TITLE
Add x402 Agent Kit and SignalFuse Starter Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [x402 Agent Kit](https://github.com/hypeprinter007-stack/x402-agent-kit) — Python payment SDK for AI agents to call any x402-enabled API with USDC on Base.
 
 
 ### Standards and EIPs
@@ -79,6 +80,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [SignalFuse Starter Bot](https://github.com/hypeprinter007-stack/signalfuse-starter-bot) — Hyperliquid trading bot that pays for fused signals via x402 micropayments.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary
- Adds **x402 Agent Kit** to Open Source & SDKs — Python payment SDK for AI agents to call any x402-enabled API with USDC on Base.
- Adds **SignalFuse Starter Bot** to Example Apps — Hyperliquid trading bot that pays for fused signals via x402 micropayments.

Both are open-source projects that extend the x402 ecosystem with Python tooling and a real-world trading use case.