### PR TITLE
Add Satoshi API and Satoshi Facilitator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [Satoshi Facilitator (Base + Solana)](https://x402-facilitator.happysmoke-e4fd0a77.eastus.azurecontainerapps.io) ([GitHub](https://github.com/Bortlesboat/x402-facilitator)) — Open-source multi-chain facilitator with gas sponsoring, bazaar discovery, and settlement history API.
 
 
 ### Open Source & SDKs

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence APIs for agents and apps with x402-payable endpoints. [Docs](https://bitcoinsapi.com/docs)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
@@ -32,7 +33,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
-- [Satoshi Facilitator (Base + Solana)](https://facilitator.bitcoinsapi.com) ([GitHub](https://github.com/Bortlesboat/x402-facilitator)) — Open-source multi-chain facilitator with gas sponsoring, bazaar discovery, and settlement history API.
+- [Satoshi Facilitator](https://bitcoinsapi.com/docs) ([Supported](https://facilitator.bitcoinsapi.com/supported)) - Independent x402 facilitator for Bitcoin-focused pay-per-call services with Base, Base Sepolia, Solana Mainnet, and Solana Devnet support.
 
 
 ### Open Source & SDKs

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
-- [Satoshi Facilitator (Base + Solana)](https://x402-facilitator.happysmoke-e4fd0a77.eastus.azurecontainerapps.io) ([GitHub](https://github.com/Bortlesboat/x402-facilitator)) — Open-source multi-chain facilitator with gas sponsoring, bazaar discovery, and settlement history API.
+- [Satoshi Facilitator (Base + Solana)](https://facilitator.bitcoinsapi.com) ([GitHub](https://github.com/Bortlesboat/x402-facilitator)) — Open-source multi-chain facilitator with gas sponsoring, bazaar discovery, and settlement history API.
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
## Summary
- add a `Satoshi API` link under the ecosystem section
- update the existing `Satoshi Facilitator` entry with cleaner positioning and a working docs target
- consolidate the service + facilitator additions onto this older open PR

## Why
`Satoshi API` is a live Bitcoin x402 service for agents and apps, with pay-per-call endpoints for fee market analysis, next-block mining data, and transaction intelligence.

`Satoshi Facilitator` is the independent infrastructure layer behind that service and currently supports Base, Base Sepolia, Solana Mainnet, and Solana Devnet.

## Validation
As of `2026-04-20`, the public integration surfaces resolve and return live discovery data:
- `https://bitcoinsapi.com/.well-known/x402`
- `https://bitcoinsapi.com/api/openapi.json`
- `https://facilitator.bitcoinsapi.com/supported`
- `https://facilitator.bitcoinsapi.com/discovery/resources?origin=https://bitcoinsapi.com`

## Notes
- this PR now supersedes the newer duplicate thread that was adding overlapping Merit list entries
- the facilitator list entry points to docs instead of the bare facilitator root so readers land on a working user-facing page