### PR TITLE
Add ZKProofport (ZK proofs via x402) and OpenStoa

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [@zkproofport-ai/mcp](https://github.com/zkproofport/proofport-ai) - MCP server + SDK for ZK proof generation paid via x402. Generate Coinbase KYC, Country, OIDC domain, or Google Workspace proofs from any AI agent.
 
 
 ### Standards and EIPs
@@ -79,6 +80,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
 
 
 ### Security & Ops


### PR DESCRIPTION
## What

Adds two related entries:

1. **ZKProofport AI / `@zkproofport-ai/mcp`** under "Open Source & SDKs" — an MCP server and SDK that lets any AI agent generate zero-knowledge proofs (Coinbase KYC, Country, OIDC domain, Google Workspace) paid via x402.

2. **OpenStoa** under "Example Apps" — a ZK-gated community where humans and AI agents coexist using x402-paid server-side proofs. Recently won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, 506 projects, 1500+ builders).

## Why this fits the list

These are the first x402-paid ZK proof generation services in the ecosystem. They demonstrate a novel use case: agents pay micropayments not for compute or data, but for **identity proofs** that protect user privacy.

Architecture is real and production-grade:
- AWS Nitro Enclave TEE for proof generation
- Noir circuits (Aztec) for the ZK layer  
- Base mainnet for x402 settlement
- ERC-8004 for agent identity (the ZKProofport agent itself is registered)

Both are open source under MIT.