### PR TITLE
feat: add AgentShield DEX Spread Oracle to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [AgentShield DEX Spread Oracle](https://europe-west1-arbitrage-agent-prod.cloudfunctions.net/dex-spread-oracle) – Real-time Uniswap V3 price feeds on Base chain with cross-pair spread analysis. Pay-per-query via x402 ($0.01 USDC). [ERC-8004 Agent Card](https://8004agents.ai/agent/38580).
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary
- Add **AgentShield DEX Spread Oracle** to the Example Apps section
- Real-time Uniswap V3 price feeds on Base chain with cross-pair spread analysis
- Pay-per-query via x402 ($0.01 USDC on Base via PayAI facilitator)
- Features: 5 Uniswap V3 pairs, block-level data, spread analysis
- Includes link to [ERC-8004 Agent Card](https://8004agents.ai/agent/38580)

## Details
The AgentShield DEX Spread Oracle is a live x402-enabled service endpoint that provides real-time DEX price data. It fits naturally in the Example Apps section alongside other working x402-powered services like the Hyperbolic Chat API and Pinata IPFS pinning.

## Test plan
- [x] Verified new entry follows existing markdown list format
- [x] Entry placed in the Example Apps section alongside similar services
- [x] URL and description are accurate