### PR TITLE
Add Ai Crypto API to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Ai Crypto API](https://github.com/aoi-dev-0411/x402-crypto-api) – Multi-endpoint crypto data API (prices, gas, DeFi yields, market analysis) monetized via x402 on Base with USDC micropayments.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

Adds [Ai Crypto API](https://github.com/aoi-dev-0411/x402-crypto-api) to the Example Apps section.

Multi-endpoint crypto data API (prices, gas, trending, DeFi yields, market analysis) monetized via x402 micropayments on Base (USDC). Uses `@x402/server` middleware with OpenFacilitator.

Closes #10