### PR TITLE
Add agentsvc.io to Ecosystem — live x402 service marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [agentsvc.io](https://agentsvc.io) - Live pay-per-call service marketplace for AI agents. 20 utility tools (screenshots, OCR, PDF, web search, weather, forex, crypto/stock prices, geocoding, translation, and more) via x402 USDC micropayments. No API keys. MCP server included. $0.001–$0.008 per call.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
## What this adds

**[agentsvc.io](https://agentsvc.io)** — a live production x402 service marketplace that lets AI agents pay for 20 utility tools per-call in USDC on Base Mainnet. Added to the Ecosystem section.

### Why Ecosystem?
It's infrastructure for the x402 ecosystem — a production service that makes x402 immediately practical for AI agents without any setup.

### Details
- 20 tools: screenshots, OCR, PDF, web scraping, weather, forex, crypto/stock prices, DNS, geocoding, translation, and more
- $0.001–$0.008 USDC per call, Base Mainnet, x402 exact scheme
- MCP server (`agentsvc.io/mcp-server.mjs`) for Claude Desktop and other MCP clients
- Auto-discovery: `/.well-known/agent-services.json`
- No API keys, no accounts, no subscriptions