### PR TITLE
Add Bermuda — ZK-private payments for x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
-- [Bermuda (ZK-private x402)](https://github.com/BermudaBay/sdk) - ZK-private HTTP payments for x402 using Noir proofs on Base. Adds sender privacy so agents can pay without exposing wallet state. ([Website](https://www.bermudabay.xyz))
+- [Bermuda (ZK-private x402)](https://www.bermudabay.xyz) - ZK-private HTTP payments for x402 using Noir proofs on Base. Adds sender privacy so agents can pay without exposing wallet state. ([Docs](https://docs.bermudabay.xyz/sdk/x402))
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
+- [Bermuda (ZK-private x402)](https://github.com/BermudaBay/sdk) - ZK-private HTTP payments for x402 using Noir proofs on Base. Adds sender privacy so agents can pay without exposing wallet state. ([Website](https://www.bermudabay.xyz))
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol


### PR DESCRIPTION
## Summary
- Adds Bermuda to the Open Source & SDKs section
- Bermuda provides ZK-private HTTP payments for x402 using Noir zero-knowledge proofs on Base

**Website:** https://www.bermudabay.xyz
**GitHub:** https://github.com/BermudaBay/sdk