### PR TITLE
Add Radius Network x402 Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [Radius Network x402 Integration](https://docs.radiustech.xyz/developer-resources/x402-integration)
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Add Radius Network x402 integration docs to Facilitators & Networks.

Radius Network is an EVM-compatible stablecoin L1 with x402 settlement support (Permit2 + EIP-2612). The linked page covers x402 request lifecycles, facilitator patterns, and code examples for building on Radius.