### PR TITLE
Add CIPHER Premium (Solana MEV Deep Dive) to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [CIPHER Premium — Solana MEV Deep Dive](https://cipher-x402.vercel.app) — x402-gated 5,000-word expansion of the free CIPHER Solana Quant Playbook, covering Jito tip math, dynamic oracle-gate bps, illiquidity blocklist heuristics, sim-vs-reality divergence, and a $1k MEV test matrix. $0.25 USDC on Base per fetch. [Gated route](https://cipher-x402.vercel.app/premium/mev-deep-dive) returns HTTP 402 with v2 accept-list. [Free companion playbook](https://github.com/cryptomotifs/cipher-starter).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adding a new x402-gated example app: **CIPHER Premium — Solana MEV Deep Dive**.

- Live URL: https://cipher-x402.vercel.app
- Gated route (returns HTTP 402 with v2 accept-list): https://cipher-x402.vercel.app/premium/mev-deep-dive
- Free companion playbook (MIT): https://github.com/cryptomotifs/cipher-starter

**What the gated route offers**: a 5,000-word premium chapter expanding the public CIPHER Solana Quant Playbook with:
- Jito bundle tip math (closed-form break-even under different sandwich probabilities)
- Dynamic oracle-gate bps tuning by liquidity regime
- Illiquidity blocklist heuristics
- Six-channel sim-vs-reality divergence analysis
- Multi-DEX re-route decision rule
- $1k 72-hour test matrix (5 configs)

**Settlement**: $0.25 USDC on Base mainnet (eip155:8453). Asset: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`. Payout: `0xa0630fAD18C732e94D56d2D5F630963eb8fB9640`.

Happy to update the positioning if you'd like it in a different subsection.
