### PR TITLE
Add Scout MCP to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Scout MCP](https://scout.hugen.tokyo) ([Source](https://github.com/bartonguestier1725-collab/scout-mcp)) – Multi-source search MCP server with a public x402 HTTP API. Covers code registries, academic papers, social platforms, and developer community blogs in one call. Live on Base mainnet.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

Adds Scout MCP to the Example Apps section. It is an MCP stdio server paired with a public x402 HTTP API — useful as a reference for anyone building MCP servers that are also addressable over x402.

- MCP surface via `npx -y scout-cli` (Claude Desktop, Cursor, Claude Code compatible)
- HTTP surface at `https://scout.hugen.tokyo` with x402 micropayments (USDC on Base)
- Source: https://github.com/bartonguestier1725-collab/scout-mcp
- License: MIT

No breaking changes, single-line addition.