### PR TITLE
Add Fly Labs Agentic Market to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [Fly Labs Agentic Market](https://flylabs.fun/agents) - YouTube data APIs for AI agents. Verbatim transcripts ($0.03) and engagement data ($0.02) — views, likes, comments, subscribers, ratios, tags. USDC on Base via x402, Coinbase CDP facilitator. Versioned schemas, no signup. ([Manifest](https://flylabs.fun/api/agents) · [OpenAPI](https://flylabs.fun/api/agents/openapi.json) · [.well-known/x402](https://flylabs.fun/.well-known/x402))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [Fly Labs Agentic Market](https://flylabs.fun/agents) to the Ecosystem section.

Two live paid endpoints on Base mainnet:

- **`POST /api/agents/transcribe`** — $0.03/call. Verbatim YouTube transcripts with versioned v1.0 schema (time-indexed paragraphs, chapters, metadata). Cached permanently.
- **`POST /api/agents/engagement`** — $0.02/call. Views, likes, comments, subscribers, engagement ratios, tags, channel info. Cached 6 hours.

Payment: USDC via x402, Coinbase CDP facilitator. Settlement verified on-chain.

Discovery:
- Manifest: https://flylabs.fun/api/agents
- OpenAPI 3.1: https://flylabs.fun/api/agents/openapi.json
- https://flylabs.fun/.well-known/x402
- https://flylabs.fun/.well-known/agent-card.json

No signup, no keys, no rate limits.