### PR TITLE
Add AlgoVoi multi-chain x402 facilitator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [AlgoVoi Facilitator & Supported Networks](https://api1.ilovechicken.co.uk/.well-known/agent.json) — multi-chain x402 facilitator spanning EVM (Base, Tempo), SVM (Solana, with Solana Pay `reference` binding), AVM (Algorand, VOI), Stellar, and Hedera on a single endpoint
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Adds AlgoVoi to the Facilitators & Networks list.

Fills a non-EVM gap in the current entries (Coinbase, PayAI, thirdweb, Corbits). AlgoVoi spans EVM (Base, Tempo), SVM (Solana with Solana Pay `reference` pubkey binding), AVM (Algorand, VOI), Stellar, and Hedera on one x402 endpoint. Production — live at api1.ilovechicken.co.uk with [open-source MCP adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters).