### PR TITLE
Add Social Intel API to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Social Intel API](https://socialintel.dev) — Pay-per-request Instagram influencer search API. x402 USDC on Base, Solana, Polygon, Arbitrum. MCP server, OpenAPI, free demo. ([MCP Repo](https://github.com/socialintel/social-intel-mcp))
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds [Social Intel API](https://socialintel.dev) — a pay-per-request Instagram influencer search API — to the **Example Apps** section.

Note on placement: Example Apps currently mixes demos, blog posts, and starter kits. Social Intel is a production service, so this is a mild force-fit. **Happy to relocate** if you'd like to add a `### Production Services` (or `### Live x402 Services`) section — would also be a useful surface for similar production endpoints.

What it does:
- Instagram influencer search by niche, country, demographics, follower count
- Single-profile lookup at \$0.01; full search \$0.50–\$1.30 (1–100 results)
- USDC on Base, Solana, Polygon, Arbitrum (CDP facilitator primary, PayAI fallback)
- MCP server + OpenAPI; no signup or API keys
- Listed on agentic.market and 402index.io

Single-line addition; no other changes.