### PR TITLE
docs: add Cloudflare Agents x402 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Cloudflare Agents x402 Example](https://github.com/cloudflare/agents/tree/main/examples/x402) – Official example showing how to gate Cloudflare Agents endpoints with x402 payments.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary
- add the official Cloudflare Agents x402 example to the Example Apps section
- provide a primary-source reference for building agent endpoints gated by x402 payments

## Validation
- verified the GitHub resource URL returns HTTP 200
- ran `git diff --check`

Resolves #10
