### PR TITLE
Add NicheData KDP Intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [NicheData KDP Intelligence API](https://nichedata.dev) - Niche research data API for AI agents. KDP keyword demand, competition, BSR ranges, and revenue estimates. $0.03 USDC per query on Base via CDP Facilitator. ([OpenAPI](https://nichedata.dev/openapi.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [NicheData KDP Intelligence API](https://nichedata.dev) to the Ecosystem section.

**What it is:** A niche research data API for AI agents focused on Kindle Direct Publishing. Agents query keyword-level intelligence — demand scores, competition intensity, BSR ranges, revenue estimates, and pricing analytics.

**x402 details:**
- $0.03 USDC per query on Base L2
- CDP Facilitator for payment verification
- OpenAPI 3.1.0 spec: https://nichedata.dev/openapi.json
- Free discovery endpoint: `GET /v1/niches`