### PR TITLE
Add Gatefare MCP to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
 - [MCPay (Build and Monetize MCP servers. SDK, Infrastructure and Examples)](https://github.com/microchipgnu/mcpay)
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
+- [Gatefare MCP](https://github.com/gatefareio/mcp-server) — Marketplace MCP server for paid HTTP APIs. 13 tools across discovery, buyer (auto 402→sign→retry), and publisher domains. Non-custodial, USDC on Base. Listed in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=gatefareio). Install: `npx -y @gatefare/mcp`. ([npm](https://www.npmjs.com/package/@gatefare/mcp))
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 


### PR DESCRIPTION
Adds [Gatefare MCP](https://github.com/gatefareio/mcp-server) to the **Open Source & SDKs** section, alongside the existing MCP entries (`MCPay`, `x402-mcp package`).

Gatefare MCP is a marketplace MCP server: agents discover paid HTTP APIs in the Gatefare catalog, call them (the server auto-handles 402 → EIP-3009 sign → retry), and optionally publish their own APIs. Non-custodial — keys stay in env.

- npm: https://www.npmjs.com/package/@gatefare/mcp (`v1.0.1`)
- MCP Registry: live as `io.github.gatefareio/mcp-server`
- Marketplace: https://gatefare.io
- License: MIT, 138 unit + 10 e2e tests

Inserted right after `x402-mcp package` in alphabetical/topical proximity.