### PR TITLE
Add agent-marketplace-proxy as Example App

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) under Example Apps. Reference implementation of the commodity-API-resale pattern — ~80 lines of Express wrap any upstream REST API with x402-express. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. Live: https://agent-marketplace-proxy.vercel.app