### PR TITLE
Add MoltPe to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [MoltPe (AI agent payment infrastructure)](https://github.com/umangbuilds/moltpe-agent-payments) - Non-custodial agent wallets with Shamir key splitting, programmable spending policies, and tri-rail support: x402 (HTTP-native), MPP (session-based), and fiat. 11 MCP tools for Claude Desktop, Cursor, Windsurf. Sub-second settlement on Polygon PoS, Base, Tempo. Free tier, no credit card. ([Site](https://moltpe.com))
 
 
 ### Standards and EIPs


### PR DESCRIPTION
## What

Adds **MoltPe** to the Open Source & SDKs section.

## Description

MoltPe is AI-native payment infrastructure purpose-built for autonomous AI agents:

- **Non-custodial agent wallets** with Shamir key splitting
- **Programmable spending policies** (daily caps, per-tx caps, recipient allowlists, cooldowns) enforced at the infrastructure level
- **Tri-rail support**: x402 (HTTP-native micropayments), MPP (session-based), and traditional fiat
- **11 MCP tools** for Claude Desktop, Cursor, Windsurf
- **Multi-chain USDC** on Polygon PoS, Base, Tempo with sub-second settlement
- Free tier, no credit card

Public reference implementation: https://github.com/umangbuilds/moltpe-agent-payments (Apache 2.0, 87 tests passing)

Production: https://moltpe.com