### PR TITLE
Add Onyx Bazaar to Ecosystem section — free public x402 leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
+- [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) - Free public leaderboard of every paid x402 service indexed via the Coinbase CDP discovery API. Refreshed every 15 min, four views (top by volume / unique payers / recently active / cheapest), JSON variant at `/bazaar.json`. Complementary CDP-only slice next to x402Scan's multi-source view.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 
 ### Facilitators & Networks


### PR DESCRIPTION
Adds [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) under the **Ecosystem** section, alongside x402Scan and x402station.

**What it is:** A free public leaderboard of every paid x402 service, pulled from Coinbase's CDP discovery API and refreshed every 15 minutes. Four views — top by volume / most unique payers / recently active / cheapest. JSON variant at `/bazaar.json` for programmatic consumers. No auth, no signup.

**Live data right now:** 1,000 services indexed / 122,290 calls per 30 days, distributed across:
- Base mainnet — 949 services
- Solana — 33 services
- Base-Sepolia — 17 services
- Stellar testnet — 1 service

**Top of leaderboard right now:**
- `api.exa.ai/search` — 69,343 calls, 151 payers @ $0.007
- `api.oatp.cc/tx_explainer` (Solana) — 7,519 calls, 920 unique payers @ $0.10
- `api.molty.cash` — 5,873 calls @ $0.11

**Positioning:** Complementary to x402Scan, not replacement. x402Scan pulls multiple sources (multi-facilitator, broader network coverage); Onyx Bazaar pulls only the Coinbase CDP facilitator, which is the gravity well for Base mainnet x402 traffic. The two views together give the ecosystem a CDP-canonical view + a multi-source comparison view.

**Verifiable links:**
- Live dashboard: https://onyx-actions.onrender.com/bazaar
- JSON: https://onyx-actions.onrender.com/bazaar.json
- Source repo (MIT): https://github.com/dimitrilaouanis-tech/onyx-mcp
- Built on the open-source `onyx-paid-mcp` framework

Single-line addition to the Ecosystem subsection — happy to adjust the wording or move it elsewhere if it fits the list better.
