### PR TITLE
Add Pyrimid and AgentZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Ecosystem
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
+- [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
+- [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 


### PR DESCRIPTION
Adds Pyrimid and AgentZone to the ecosystem section.\n\nPyrimid covers x402/ERC-8004 agent commerce routing and payment splitting. AgentZone provides a unified explorer for ERC-8004 identities, x402 payment history, reputation, and service status.