### PR TITLE
Add Nishvault Blind-Send Risk Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+- [Nishvault Blind-Send Risk Guard](https://www.npmjs.com/package/nishvault-preflight-buy) - x402-paid pre-send risk guard for EVM agent builders. Put `nishvault-guard-tx` directly before `sendTransaction` to inspect revert risk, fee context, and likely call outcome before broadcast.
 
 
 ### Standards and EIPs


### PR DESCRIPTION
Adds Nishvault Blind-Send Risk Guard to the Open Source & SDKs section.

Nishvault is an x402-paid pre-send risk guard for programmatic EVM agent builders. It is designed to sit immediately before `sendTransaction`/broadcast, with:

- npm package: `nishvault-preflight-buy`
- CLI guard: `npx --package nishvault-preflight-buy nishvault-guard-tx`
- live x402 discovery: `https://api.nishvault.com/.well-known/x402`
- no-wallet first check: `https://api.nishvault.com/first-unpaid-402?autorun=1`

This fits the list as a developer-facing x402 SDK/tooling resource for agent transaction safety.