### PR TITLE
add AlgoVoi multi-protocol facilitator (7 networks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [AlgoVoi Multi-Protocol Facilitator (7 networks)](https://docs.algovoi.co.uk/concepts/xchain) - x402 + MPP + AP2 facilitator covering Base, Solana, Stellar, Algorand, VOI, Hedera, and Tempo. xChain bridges EVM USDC to Solana (Circle CCTP V2, ~50s), Stellar (Allbridge Core, classic Circle USDC at issuer GA5ZSEJ…), and Algorand from MetaMask without a destination wallet.
+  - [Live `pay.sh`-compatible catalog](https://api.algovoi.co.uk/.well-known/pay-skills.json)
+  - [Discovery (a2a / x402)](https://api.algovoi.co.uk/.well-known/agent-card.json)
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
## What this adds

A single bullet under **Facilitators & Networks** for AlgoVoi — a multi-protocol (x402 + MPP + AP2) facilitator covering seven mainnet networks: Base, Solana, Stellar, Algorand, VOI, Hedera, and Tempo. Plus two child links pointing at the live `pay.sh`-compatible catalog endpoint and the a2a / x402 discovery card.

## Why it fits this list

- **Multi-chain** in a section currently dominated by Base-only facilitators. AlgoVoi is the only listed entry covering Stellar, Algorand, VOI, Hedera, and Tempo behind a single x402 endpoint.
- **xChain bridge UX** — agents and humans holding USDC on any of seven supported EVM source chains (Base, Arbitrum, Polygon, Optimism, Ethereum, BNB, Avalanche) can pay AlgoVoi-protected resources from MetaMask without ever installing a destination-chain wallet. Solana routes via Circle CCTP V2 (~50s native USDC); Stellar routes via Allbridge Core's swap-and-bridge to canonical Circle USDC at issuer `GA5ZSEJ…`; Algorand uses the deterministic LogicSig pattern.
- **Stellar mainnet xChain shipped 2026-05-05.** First mainnet bridge from Base settled in ~2 minutes. Any Stellar wallet supports the delivered asset (no Soroban-aware wallet required).

## Live verification

```sh
curl -s https://api.algovoi.co.uk/.well-known/pay-skills.json \
  | jq '{version, provider_count, base_url}'
# → version 2, providers from active tenants on the 7 mainnet allowlist
```

```sh
curl -s https://api.algovoi.co.uk/.well-known/agent-card.json \
  | jq '.protocolVersion, .skills | length'
# → A2A discovery card with x402-compatible skill endpoints
```

## Cross-references

- AlgoVoi is also already filed for review in the canonical x402 ecosystem source: [x402-foundation/x402#85](https://github.com/x402-foundation/x402/pull/85)
- Aggregator PR opened today against pay.sh: [solana-foundation/pay#349](https://github.com/solana-foundation/pay/pull/349) — AlgoVoi as the first aggregator entry in pay.sh's brand-new `aggregators/` directory.

Happy to address any review feedback.
