### PR TITLE
Add cn402 (China Data Gateway) to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- * [cn402 (China Data Gateway)](https://cn402.com) – Pay-per-call APIs for AI agents serving China-specific data (FX rates, A-share quotes, mainland holidays). Built on x402 + Base mainnet USDC. [Source](https://github.com/CNX402/cn402-site)
 
 
 ### Security & Ops


### PR DESCRIPTION
## What

Adds cn402 to the Example Apps section.

## About cn402

cn402 ([cn402.com](https://cn402.com)) is a pay-per-call API gateway built on x402, focused on China-specific data for autonomous agents.

- `/forex` ($0.03) — **Live**, real-time FX rates (USDCNY and major pairs, ECB reference data)
- Settlement: USDC on Base mainnet via Coinbase CDP facilitator
- First on-chain settlement: [basescan.org/tx/0x96e74c68...d3a25d](https://basescan.org/tx/0x96e74c68b401fbddf2d73755d35ae082bb845132fd5c827a7674e73d8ed3a25d)
- Source: https://github.com/CNX402/cn402-site

Solo project. Additional endpoints (A-share quotes, China holidays, crypto indicators) in development.