### PR TITLE
Add EVM Tx Toolkit (live x402 service + open-source example app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [EVM Tx Toolkit (Money Tree)](https://github.com/sebastiancoombs/evm-tx-toolkit) — Live x402 service for Base + Ethereum: `tx/explain` ($0.10), `tx/simulate` ($0.20), and `token/risk_scan` ($0.50). Hono + viem + x402-hono on Cloudflare Workers. Ships with all 5 well-known agent-discovery manifests (A2A, MCP, OpenAI plugin, OpenAPI 3.1, agent-discovery HTML) at the deployed origin.
 
 
 ### Security & Ops


### PR DESCRIPTION
This PR adds **EVM Tx Toolkit** to the *Example Apps* section.

It is both:

1. **A live x402 service** at `https://evm-tx-toolkit.mtree.workers.dev`. Three Base/Ethereum endpoints settling USDC on Base via the canonical x402 EXACT scheme:
   - `POST /v1/tx/explain` — \$0.10 — decoded human-readable summary of a confirmed Base/Ethereum tx (transfers, swap legs, gas, revert reason).
   - `POST /v1/tx/simulate` — \$0.20 — pre-flight `eth_call` simulation with decoded revert reason and gas estimate.
   - `POST /v1/token/risk_scan` — \$0.50 — ERC-20 risk scoring with proxy detection (EIP-1967), GoPlus enrichment, and a composite 0–100 score.

2. **An open-source reference for x402-hono + viem on Cloudflare Workers.** The repo ([sebastiancoombs/evm-tx-toolkit](https://github.com/sebastiancoombs/evm-tx-toolkit)) contains the full Hono + `x402-hono` + `viem` implementation, `wrangler.toml`, smoke tests against real Base mainnet, and the auto-generated 5 well-known discovery files (A2A agent-card, MCP, OpenAI plugin, OpenAPI 3.1 with \`x-x402-price-usd\` annotations, and the \`agent-discovery\` HTML page) — useful for anyone building a discoverable x402 service.

The endpoint matrix (Base + Ethereum, \$0.10–\$0.50) intentionally fills the EVM-side gap left by [OATP](https://x402scan.com/), which serves the same three primitives on Solana.

### Quick try

\`\`\`bash
curl -i -X POST https://evm-tx-toolkit.mtree.workers.dev/v1/tx/explain \\
  -H 'content-type: application/json' \\
  -d '{"chain":"base","tx_hash":"0x..."}'
# 402 Payment Required, EXACT scheme, payTo + Base USDC asset, retry with X-PAYMENT.
\`\`\`

### Discovery manifests (live at the deployment)

- [\`/.well-known/agent-card.json\`](https://evm-tx-toolkit.mtree.workers.dev/.well-known/agent-card.json) — A2A agent card
- [\`/.well-known/mcp.json\`](https://evm-tx-toolkit.mtree.workers.dev/.well-known/mcp.json) — MCP discovery manifest
- [\`/.well-known/ai-plugin.json\`](https://evm-tx-toolkit.mtree.workers.dev/.well-known/ai-plugin.json) — OpenAI plugin manifest
- [\`/openapi.yaml\`](https://evm-tx-toolkit.mtree.workers.dev/openapi.yaml) — OpenAPI 3.1 with \`x-x402-price-usd\`
- [\`/agent-discovery\`](https://evm-tx-toolkit.mtree.workers.dev/agent-discovery) — HTML index linking all of the above

I'm happy to move this elsewhere if a more specific section emerges (a \`### Live Services\` section seems natural as the ecosystem grows — happy to open a follow-up PR proposing that).