### PR TITLE
Add Federal Procurement MCP (Money Tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Federal Procurement MCP (Money Tree)](https://procure-mcp.mtree.workers.dev/agent-discovery) — Live x402 MCP for U.S. federal procurement data: `opportunities/search` ($0.05, SAM.gov), `awards/search` ($0.03, USASpending.gov), `agencies/list` ($0.01, USASpending.gov). Hono + x402-hono on Cloudflare Workers. Ships all 5 well-known agent-discovery manifests (A2A, MCP, OpenAI plugin, OpenAPI 3.1, agent-discovery HTML) plus an MCP Streamable HTTP transport at `/mcp`. No signup, no API key — pay USDC on Base.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

Live x402 MCP service exposing **U.S. federal procurement data** with three pay-per-call endpoints — pay USDC on Base, no signup, no API key.

| Endpoint | Source | Price |
|---|---|---|
| `POST /v1/opportunities/search` | SAM.gov (RFPs / RFIs / sources sought) | $0.05 |
| `POST /v1/awards/search` | USASpending.gov contract awards | $0.03 |
| `POST /v1/agencies/list` | USASpending.gov toptier agencies + budget | $0.01 |

**Live:** https://procure-mcp.mtree.workers.dev
**Agent discovery:** https://procure-mcp.mtree.workers.dev/agent-discovery

## Stack

Hono + `x402-hono` + `@coinbase/x402` on Cloudflare Workers. Same minimal pattern as the [EVM Tx Toolkit](https://github.com/Merit-Systems/awesome-x402/pull/180) — payment middleware in one function call.

## Discovery surfaces (all unpaid, crawlable)

- `/.well-known/agent-card.json` (Google A2A)
- `/.well-known/mcp.json` (MCP server manifest)
- `/.well-known/ai-plugin.json` (OpenAI plugin)
- `/openapi.yaml` (OpenAPI 3.1)
- `/agent-discovery` (HTML landing)
- `/mcp` (MCP Streamable HTTP transport, JSON-RPC 2.0 — `initialize` / `tools/list` / `tools/call`)

## Why list it

Federal procurement data is free at the source, but every agent-friendly aggregator gates behind subscription + API key. This is the x402-native door — agents pay USDC for what they need, no human in the loop. Slot fits naturally next to the other "Live x402 services" entries already in the README.

## Test plan

- [x] `/healthz` → 200, `{"ok":true}`
- [x] All 5 well-knowns → 200
- [x] `/mcp` GET (info) → 200 with tool catalog
- [x] `POST /v1/agencies/list` without `X-PAYMENT` → 402 with valid x402 envelope (Base, USDC, $0.01 → 10000 atomic)
- [ ] `POST` with valid `X-PAYMENT` settles via x402.org default facilitator and returns USASpending data