### PR TITLE
Add FPDS-NG MCP (Money Tree)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [FPDS-NG MCP (Money Tree)](https://fpds-mcp.mtree.workers.dev/agent-discovery) — Live x402 MCP for the U.S. **Federal Procurement Data System** (every federal contract action since 2001): `contracts/search` ($0.04) and `contracts/by_vendor` ($0.05, returns rows + vendor aggregate). Hono + x402-hono on Cloudflare Workers. Ships all 5 well-known agent-discovery manifests (A2A, MCP, OpenAI plugin, OpenAPI 3.1, agent-discovery HTML) plus an MCP Streamable HTTP transport at `/mcp`. No signup, no API key — pay USDC on Base.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

Live x402 MCP service exposing the **U.S. Federal Procurement Data System (FPDS-NG)** — every federal contract action since 2001 — with two pay-per-call endpoints. Pay USDC on Base, no signup, no API key.

| Endpoint | Description | Price |
|---|---|---|
| `POST /v1/contracts/search` | FPDS contract actions by keyword / agency code / NAICS / signed-date window | **\$0.04** |
| `POST /v1/contracts/by_vendor` | Recent contract actions for a vendor + aggregate (total obligated $, distinct agencies, distinct NAICS) | **\$0.05** |

**Live:** https://fpds-mcp.mtree.workers.dev
**Repo:** https://github.com/sebastiancoombs/fpds-mcp
**Sibling:** [`procure-mcp`](https://procure-mcp.mtree.workers.dev) (PR #181) — SAM.gov + USASpending.gov

## Why it belongs here

- **First x402 wrapper of FPDS-NG.** FPDS is the canonical, source-of-truth federal-contract record; the official UI is HTML and the public ATOM feed is unfriendly to agents. This service is the x402-native door.
- **Complements** \`procure-mcp\` (SAM.gov live opportunities + USASpending.gov awards) — together they cover the full federal procurement lifecycle (opportunity → award → historical contract action).
- Built with Hono + \`x402-hono\` + \`@coinbase/x402\` on Cloudflare Workers.
- Ships **all 5 well-known agent-discovery manifests** (A2A \`agent-card.json\`, MCP \`mcp.json\`, OpenAI plugin \`ai-plugin.json\`, OpenAPI 3.1 \`openapi.yaml\`, agent-discovery HTML) plus an **MCP Streamable HTTP** transport at \`/mcp\`.

## Verified

- \`GET /healthz\` → \`200 OK\`
- \`POST /v1/contracts/by_vendor\` (no \`X-PAYMENT\`) → **\`HTTP 402\`** with valid x402 envelope (\`network=base\`, \`asset=USDC\`, \`payTo=0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de\`, \`maxAmountRequired=50000\` = \$0.05).
- All 5 well-knowns + \`/mcp\` (\`tools/list\`) → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)