### PR TITLE
Add CardZero (Ecosystem) + ERC-8004 / ERC-8183 (Standards)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
@@ -55,6 +56,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [EIP-712 — Typed Structured Data Hashing and Signing](https://eips.ethereum.org/EIPS/eip-712): canonical typed signing used by modern wallets.
 - [EIP-2612 — permit for ERC-20](https://eips.ethereum.org/EIPS/eip-2612): approvals via signatures; often complementary to authorization-based flows.
 - [ERC-4337 — Account Abstraction (AA)](https://eips.ethereum.org/EIPS/eip-4337): smart account architecture that pairs well with authorization patterns.
+- [ERC-8004 — Trustless Agents](https://eips.ethereum.org/EIPS/eip-8004): on-chain identity + reputation registries for autonomous agents; lets x402 sellers check an agent's payment history before serving.
+- [ERC-8183 — Agentic Commerce](https://eips.ethereum.org/EIPS/eip-8183): on-chain escrow standard for agent-to-agent service delivery, complementary to x402 (which handles per-request micropayments) for cases where the deliverable can't be verified by HTTP 200.
 
 #### Extensions
 - [ERC-3009 Forwarding](https://github.com/TheGreatAxios/eip3009-forwarder): forwarding contract extending meta-transactions with EIP-721 signatures to any ERC-20 on any network


### PR DESCRIPTION
Two short additions (3 lines total):

### Ecosystem → CardZero

x402-buyer-side wallet for AI agents on Base mainnet. ERC-4337 smart-contract wallet with owner-controlled spending rules (enforced on-chain). Buyer-side x402 support via `POST /v1/x402/pay`. Live in production at [cardzero.ai](https://cardzero.ai) since 2026-03.

### Standards and EIPs → ERC-8004 + ERC-8183

The two recent EIPs that compose naturally with x402:
- **ERC-8004 (Trustless Agents)** — on-chain identity + reputation registries; lets x402 sellers check an agent's payment history before serving.
- **ERC-8183 (Agentic Commerce)** — on-chain escrow for agent-to-agent service delivery; complementary to x402 (per-request micropayments) for cases where the deliverable can't be verified by HTTP 200.

CardZero runs the first known production deployment of either standard.

### Disclosure

I'm a maintainer of CardZero. The two EIP entries are independent of CardZero and would belong on this list regardless. Happy to drop the ecosystem entry if maintainers prefer.