### PR TITLE
Add edgar-mcp (x402 MCP for SEC EDGAR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [edgar-mcp](https://github.com/sebastiancoombs/edgar-mcp) – Pay-per-call x402 MCP for SEC EDGAR. Three endpoints: `filings/search` ($0.04 — full-text across every filing since 1993), `filings/by_cik` ($0.05 — recent company filing history), `filings/full_text` ($0.10 — primary-document text). USDC on Base, no signup, no API key. Live at [edgar-mcp.mtree.workers.dev](https://edgar-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **edgar-mcp** to the Example Apps section.

**What it is:** Pay-per-call x402 MCP for the SEC EDGAR filings system — every public-company filing since 1993, full-text searchable. Three endpoints:

| Endpoint | Description | Price |
|---|---|---|
| `POST /v1/filings/search` | Full-text across every EDGAR filing (query / forms / CIKs / date range) | $0.04 |
| `POST /v1/filings/by_cik` | Recent filing history for a single company by CIK | $0.05 |
| `POST /v1/filings/full_text` | De-tagged primary-document text for a specific filing | $0.10 |

USDC on **Base**, payTo `0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de`. No signup, no API key.

**Live:** https://edgar-mcp.mtree.workers.dev
**Repo:** https://github.com/sebastiancoombs/edgar-mcp

Discovery surfaces (all unpaid / 200): A2A agent-card · MCP server-card · OpenAI plugin · OpenAPI 3.1 · agent-discovery HTML · MCP Streamable-HTTP transport (`/mcp`).

Sibling MCPs from the same author already in the awesome-list pipeline: `procure-mcp` (PR #181), `fpds-mcp` (PR #182), `evm-tx-toolkit` (PR #180).