### PR TITLE
Add arxiv-mcp (x402 MCP for arXiv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [arxiv-mcp](https://github.com/sebastiancoombs/arxiv-mcp) – Pay-per-call x402 MCP for arXiv. Two endpoints: `papers/search` ($0.04 — full-text metadata across every STEM preprint with field-level operators) and `papers/by_id` ($0.05 — resolve papers by arXiv id, full metadata + abs/PDF URLs). USDC on Base, no signup, no API key. Live at [arxiv-mcp.mtree.workers.dev](https://arxiv-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **arxiv-mcp** — a live, pay-per-call x402 MCP server wrapping the public arXiv API. Two endpoints settle USDC on Base via x402:

- `POST /v1/papers/search` — **\$0.04** — Full-text metadata search across every arXiv preprint. Filter by free-text query, title, author(s), arXiv category (cs, math, stat, physics, q-bio, q-fin, econ, eess, etc.), and submitted-date range. Sort by relevance / lastUpdatedDate / submittedDate.
- `POST /v1/papers/by_id` — **\$0.05** — Resolve one or more papers by arXiv id. Modern (\`2401.12345\`) + old-style (\`cs.CL/9912001\`) ids both supported; \`arXiv:\` prefix and full abs/pdf URLs are normalised. Returns full metadata: title, authors, abstract, categories, DOI, journal-ref, comment, abs URL, PDF URL.

**No signup, no API key.** Pay USDC on Base; settle x402 and retry.

### Live

- Worker: <https://arxiv-mcp.mtree.workers.dev>
- Repo: <https://github.com/sebastiancoombs/arxiv-mcp>
- Discovery surfaces (all 200 OK): \`/.well-known/agent-card.json\` (A2A) · \`/.well-known/mcp.json\` · \`/.well-known/ai-plugin.json\` · \`/openapi.yaml\` · \`/agent-discovery\` (HTML) · \`/mcp\` (MCP Streamable HTTP, JSON-RPC 2.0)

### Why this matters

Knowledge bases are flagged across the May-2026 MCP-marketplace surveys (TheNewStack / mcpbundles) as **the most under-served MCP category** despite clear research-agent demand post-Bedrock AgentCore. arXiv is the canonical free preprint corpus across all STEM. This is the first x402 MCP for it — opens the knowledge-base vertical alongside the existing financial-data (edgar-mcp) and federal-procurement (procure-mcp, fpds-mcp) coverage.

### Verified

- \`/healthz\` → \`{"ok":true,"service":"arxiv-mcp","sources":["export.arxiv.org/api"]}\`
- \`POST /v1/papers/search\` (no \`X-PAYMENT\`) → **HTTP 402** with valid x402 envelope: \`payTo=0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de\`, \`network=base\`, \`asset=USDC\`, \`maxAmountRequired=40000\` (= \$0.04).
- MCP \`tools/list\` returns both \`papers_search\` and \`papers_by_id\` with x402 price annotations.