### PR TITLE
Add wallet-labels-mcp (live x402 MCP for EVM wallet labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [wallet-labels-mcp](https://github.com/sebastiancoombs/wallet-labels-mcp) – Pay-per-call x402 MCP for EVM wallet labels. Three endpoints: `wallet/labels` ($0.05 — composes ENS + OFAC SDN + Tornado mixer registry + on-chain ERC-20 metadata + public-label registry into one labeled view), `wallet/risk_score` ($0.10 — composite 0–100 risk score with itemized reasons), `labels/by_category` ($0.07 — list addresses in registries by category). Five chains: ethereum/base/arbitrum/optimism/polygon. USDC on Base, no signup, no API key. Live at [wallet-labels-mcp.mtree.workers.dev](https://wallet-labels-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **wallet-labels-mcp** — a live, pay-per-call x402 MCP server that composes free public sources into one labeled view of an EVM address. Three endpoints settle USDC on Base via x402:

- `POST /v1/wallet/labels` — **\$0.05** — Composes ENS, OFAC SDN list, Tornado Cash mixer registry, on-chain ERC-20 metadata, and a curated public-label registry into one view. Returns sanctioned/mixer flags, ENS name, contract-vs-EOA distinction, ERC-20 metadata for token contracts, and a tags array.
- `POST /v1/wallet/risk_score` — **\$0.10** — Returns a 0–100 composite risk score with risk_band (clean/low/medium/high/blocked) and itemized reasons array per rule fired (OFAC SDN, known-mixer, contract anomaly).
- `POST /v1/labels/by_category` — **\$0.07** — Returns all addresses in the bundled registries that match a category. Categories: sanctioned, mixer, exchange, dex, lending, stablecoin, wrapped-asset, founder, foundation, bridge, infrastructure.

Five chains supported: **ethereum, base, arbitrum, optimism, polygon**.

**No signup, no API key.** Pay USDC on Base; settle x402 and retry.

### Live

- Worker: <https://wallet-labels-mcp.mtree.workers.dev>
- Repo: <https://github.com/sebastiancoombs/wallet-labels-mcp>
- Discovery surfaces (all 200 OK): \`/.well-known/agent-card.json\` (A2A) · \`/.well-known/mcp.json\` · \`/.well-known/ai-plugin.json\` · \`/openapi.yaml\` · \`/agent-discovery\` (HTML) · \`/mcp\` (MCP Streamable HTTP, JSON-RPC 2.0)

### Why this matters

Wallet-labels are a foundational compliance/screening primitive for any agent moving funds on EVM rails. Today these are gated behind paid Chainalysis / TRM / Elliptic enterprise contracts; the public alternatives (Etherscan tag scraping, raw OFAC CSVs, Tornado pool lists) are scattered. wallet-labels-mcp **composes** them into one pay-per-call surface with a 0–100 risk score and a category-list endpoint.

### Verified

- \`/healthz\` → \`{\"ok\":true,\"service\":\"wallet-labels-mcp\",\"sources\":[\"ofac-sdn\",\"tornado-cash\",\"ens\",\"onchain-erc20\",\"public-registry\"],\"chains\":[\"ethereum\",\"base\",\"arbitrum\",\"optimism\",\"polygon\"]}\`
- \`POST /v1/wallet/labels\` (no \`X-PAYMENT\`) → **HTTP 402** with valid x402 envelope: \`payTo=0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de\`, \`network=base\`, \`asset=USDC\`, \`maxAmountRequired=50000\` (= \$0.05).
- MCP \`tools/list\` returns \`wallet_labels\`, \`wallet_risk_score\`, \`labels_by_category\` with x402 price annotations.