### PR TITLE
Add wallet-portfolio-risk-mcp (live x402 MCP — 5-source DeFi portfolio risk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [wallet-portfolio-risk-mcp](https://github.com/sebastiancoombs/wallet-portfolio-risk-mcp) – Pay-per-call x402 MCP for EVM wallet portfolio risk. Two endpoints: `wallet/portfolio_risk` ($0.30 — composes Aave V3 health factor + Compound III debt/liquidation status + Uniswap V3 LP count + top-N ERC-20 holdings concentration + GoPlus token-security flags into a 0–100 risk score with itemized reasons; multichain), `wallet/liquidation_alert_threshold` ($0.10 — Aave V3 + Compound III liquidation slice with urgency level + drop-to-liquidation %). Five chains: ethereum/base/arbitrum/optimism/polygon. USDC on Base, no signup, no API key. Live at [wallet-portfolio-risk-mcp.mtree.workers.dev](https://wallet-portfolio-risk-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **wallet-portfolio-risk-mcp** — a live, pay-per-call x402 MCP server that fuses 5 free public DeFi sources into a single 0–100 portfolio-risk view per EVM address. Two endpoints settle USDC on Base via x402:

- `POST /v1/wallet/portfolio_risk` — **$0.30** — Composite portfolio-risk view. Composes:
  - **Aave V3** Pool.getUserAccountData → health factor, collateral, debt, LTV, liquidation threshold
  - **Compound III** Comet.borrowBalanceOf + isLiquidatable across base-asset markets
  - **Uniswap V3** NonfungiblePositionManager.balanceOf → LP NFT count + IL exposure flag
  - **Top-N ERC-20 holdings** multicall balanceOf across ~10 popular assets per chain + native balance + concentration analysis
  - **GoPlus token-security** flags (honeypot/blacklist/proxy/mintable/transfer-pausable/selfdestruct) for held tokens
  
  Returns aggregate + per-chain risk score (0–100) with itemized `reasons` array and a `risk_band` classifier (clean/low/medium/high).
- `POST /v1/wallet/liquidation_alert_threshold` — **$0.10** — Lightweight liquidation slice (Aave V3 + Compound III only). Returns `urgency` level (none/watch/elevated/high/critical), per-protocol alert payloads, and the approximate collateral-price drop tolerance before HF→1.

Five chains supported: **ethereum, base, arbitrum, optimism, polygon**.

**No signup, no API key.** Pay USDC on Base; settle x402 and retry.

### Live

- Worker: <https://wallet-portfolio-risk-mcp.mtree.workers.dev>
- Repo: <https://github.com/sebastiancoombs/wallet-portfolio-risk-mcp>
- Discovery surfaces (all 200 OK): `/.well-known/agent-card.json` (A2A) · `/.well-known/mcp.json` · `/.well-known/ai-plugin.json` · `/openapi.yaml` · `/agent-discovery` (HTML) · `/mcp` (MCP Streamable HTTP, JSON-RPC 2.0)

### Why this matters

Liquidation risk and portfolio-concentration risk are *the* core questions any agent moving funds on EVM rails needs to answer before acting. Today these are gated behind paid DeBank Pro / Zapper / Zerion / TRM / Chainalysis subscriptions. The free public alternatives (each protocol's RPC-readable view, GoPlus public API, raw multicall) are scattered. This MCP **composes** them into a single $0.30/call surface, plus a $0.10 liquidation-only slice for cheap continuous monitoring.

Pricing rationale: composition of 5 sources commands the $0.20+ band per the [x402scan high-margin scan](https://x402scan.com) — the entire blockchain-tooling premium tier sits at $0.20–$0.50/call.

### Verified

- `/healthz` → `{"ok":true,"service":"wallet-portfolio-risk-mcp","sources":["aave-v3","compound-iii","uniswap-v3-lp","erc20-holdings","goplus-token-security"],"chains":["ethereum","base","arbitrum","optimism","polygon"]}`
- `POST /v1/wallet/portfolio_risk` (no `X-PAYMENT`) → **HTTP 402** with valid x402 envelope: `payTo=0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de`, `network=base`, `asset=USDC`, `maxAmountRequired=300000` (= \$0.30).
- `POST /v1/wallet/liquidation_alert_threshold` (no `X-PAYMENT`) → **HTTP 402** with `maxAmountRequired=100000` (= \$0.10).
- MCP `tools/list` returns `wallet_portfolio_risk`, `wallet_liquidation_alert_threshold` with x402 price annotations.