### PR TITLE
Add defi-position-health-mcp (live x402 MCP — Morpho/Aerodrome/Pendle/Lido)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [defi-position-health-mcp](https://github.com/sebastiancoombs/defi-position-health-mcp) – Pay-per-call x402 MCP for EVM DeFi position health. Two endpoints: `wallet/defi_position_health` ($0.30 — composes Morpho Blue borrow/collateral positions + Aerodrome AERO + veAERO governance lock + Pendle PT (fixed-yield) holdings + Lido LST balances into a 0–100 health score with itemized reasons; multichain), `wallet/defi_protocol_breakdown` ($0.10 — per-protocol position list, single chain, no aggregate score). Five chains: ethereum/base/arbitrum/optimism/polygon. Companion to wallet-portfolio-risk-mcp (Aave/Compound/UniV3) — covers the next-generation DeFi stack. USDC on Base, no signup, no API key. Live at [defi-position-health-mcp.mtree.workers.dev](https://defi-position-health-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **defi-position-health-mcp** — a live, pay-per-call x402 MCP server that fuses 4 next-generation DeFi sources into a single 0–100 position-health view per EVM address. Two endpoints settle USDC on Base via x402:

- `POST /v1/wallet/defi_position_health` — **\$0.30** — Composite DeFi position-health view. Composes:
  - **Morpho Blue** `position(id, user)` → supplyShares + borrowShares + collateral across curated top markets per chain (USDC/wstETH, USDC/WBTC, WETH/wstETH, WETH/weETH on Ethereum; USDC/cbBTC, USDC/wstETH, USDC/cbETH on Base)
  - **Aerodrome (Base)** AERO ERC-20 `balanceOf` + veAERO NFT count → DEX/governance exposure + voting-lock illiquidity flag
  - **Pendle** top-N PT (Principal Token) `balanceOf` → fixed-yield exposure across stETH / eETH / sUSDe / USDe / rsETH on Ethereum + Arbitrum
  - **Lido** stETH (Ethereum) and wstETH (multichain) `balanceOf` → LST exposure / de-peg risk
  
  Returns aggregate + per-chain health score (0–100) with itemized \`reasons\` array, a \`health_band\` classifier (clean/low/medium/high), and a diversification credit when ≥3 protocols are active.
- `POST /v1/wallet/defi_protocol_breakdown` — **\$0.10** — Lightweight per-protocol position list, single chain, no aggregate score. Cheaper when you only need the position breakdown.

Five chains supported: **ethereum, base, arbitrum, optimism, polygon**.

**No signup, no API key.** Pay USDC on Base; settle x402 and retry.

### Companion service

This is the second tier of a deliberate two-MCP coverage. [\`wallet-portfolio-risk-mcp\`](https://wallet-portfolio-risk-mcp.mtree.workers.dev) covers the legacy big-3 (Aave V3 + Compound III + Uniswap V3) plus token-security flags. \`defi-position-health-mcp\` covers the next-generation stack (Morpho Blue + Aerodrome + Pendle + Lido). Together they answer "what is this wallet exposed to across DeFi?" without overlap.

### Live

- Worker: <https://defi-position-health-mcp.mtree.workers.dev>
- Repo: <https://github.com/sebastiancoombs/defi-position-health-mcp>
- Discovery surfaces (all 200 OK): \`/.well-known/agent-card.json\` (A2A) · \`/.well-known/mcp.json\` · \`/.well-known/ai-plugin.json\` · \`/openapi.yaml\` · \`/agent-discovery\` (HTML) · \`/mcp\` (MCP Streamable HTTP, JSON-RPC 2.0)

### Why this matters

Morpho Blue is now the largest non-Aave/Compound lender on Ethereum + Base. Aerodrome is the dominant Base DEX. Pendle is the de-facto fixed-yield primitive. Lido remains the liquid-staking leader. Any agent reasoning about a wallet's full DeFi exposure needs visibility into these protocols — but each has its own SDK, indexer, or paid analytics tier (DeBank Pro, Zapper, Zerion). This MCP **composes** them into one \$0.30/call surface.

Pricing rationale: composition of 4 sources commands the \$0.20+ band per the [x402scan high-margin scan](https://x402scan.com) — the entire blockchain-tooling premium tier sits at \$0.20–\$0.50/call.

### Verified

- \`/healthz\` → \`{"ok":true,"service":"defi-position-health-mcp","sources":["morpho-blue","aerodrome","pendle","lido"],"chains":["ethereum","base","arbitrum","optimism","polygon"]}\`
- \`POST /v1/wallet/defi_position_health\` (no \`X-PAYMENT\`) → **HTTP 402** with valid x402 envelope: \`payTo=0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de\`, \`network=base\`, \`asset=USDC\`, \`maxAmountRequired=300000\` (= \\\$0.30).
- \`POST /v1/wallet/defi_protocol_breakdown\` (no \`X-PAYMENT\`) → **HTTP 402** with \`maxAmountRequired=100000\` (= \\\$0.10).
- MCP \`tools/list\` returns \`defi_position_health\`, \`defi_protocol_breakdown\` with x402 price annotations.