### PR TITLE
Add mev-history-mcp — x402 MCP for EVM MEV history

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [mev-history-mcp](https://github.com/sebastiancoombs/mev-history-mcp) – Pay-per-call x402 MCP for EVM MEV history. Three endpoints: `wallet/mev_exposure` ($0.30 — composite per-wallet MEV exposure score 0–100, sandwich count, swap count, attacker/frontrun/backrun details), `tx/sandwich_check` ($0.05 — single-tx sandwich classifier with confidence none/weak/medium/strong/confirmed), `pool/recent_mev_density` ($0.10 — pool-level recent sandwich density 0.0–1.0 + sample sandwiches). Block-position heuristic + DEX-router routing + gas-priority pattern. Five chains: ethereum/base/arbitrum/optimism/polygon. USDC on Base, no signup, no API key. Live at [mev-history-mcp.mtree.workers.dev](https://mev-history-mcp.mtree.workers.dev).
 
 
 ### Security & Ops


### PR DESCRIPTION
## What
New x402 service: **mev-history-mcp** — pay-per-call MCP for EVM MEV history.

Live: https://mev-history-mcp.mtree.workers.dev
Repo: https://github.com/sebastiancoombs/mev-history-mcp

## Endpoints
| Path | Price | Description |
| --- | --- | --- |
| `POST /v1/wallet/mev_exposure` | $0.30 | Composite — samples recent blocks, applies block-position sandwich heuristic to wallet's swap-related tx. Returns 0–100 exposure score, sandwich count, swap count, attacker/frontrun/backrun details. |
| `POST /v1/tx/sandwich_check` | $0.05 | Single-tx classifier. Returns `is_sandwiched` + confidence (none/weak/medium/strong/confirmed) + attacker_addr + frontrun/backrun details. |
| `POST /v1/pool/recent_mev_density` | $0.10 | Scans pool's recent logs, runs sandwich heuristic per tx. Returns sandwich_density (0.0–1.0) + density_band + sample sandwiches. |

## Methodology
Block-position heuristic — flag tx N as sandwiched iff (a) tx N-1 and N+1 share a from-address that differs from tx N, AND (b) all three target a known DEX router on the same chain. Gas-priority confirmation requires `gas_price[N-1] > gas_price[N] >= gas_price[N+1]`.

DEX router list covers Uniswap V2/V3/UniversalRouter, Aerodrome, Velodrome, Camelot, QuickSwap, 1inch, 0x, CoW, Sushi, Paraswap.

## Chains
ethereum / base / arbitrum / optimism / polygon. Public RPC fallback chain (Cloudflare-eth, Llama, PublicNode, Ankr) — no API key needed.

## Discovery
- A2A agent-card → `/.well-known/agent-card.json`
- MCP server-card → `/.well-known/mcp.json`
- OpenAI plugin → `/.well-known/ai-plugin.json`
- OpenAPI 3.1 → `/openapi.yaml`
- MCP Streamable HTTP transport → `POST /mcp`

USDC on Base via x402, no signup, no API key.