### PR TITLE
Add 6 Money Tree crypto-market x402 MCPs (0x, 1inch, CoinCap, Coinpaprika, CryptoCompare, Messari)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [0x-mcp – x402 MCP wrapper for the 0x DEX-aggregator API](https://github.com/sebastiancoombs/0x-mcp) – Pay-per-call swap quotes / indicative prices / supported sources across Ethereum, Base, Arbitrum, Optimism, Polygon. Live: https://0x-mcp.mtree.workers.dev
+- [1inch-mcp – x402 MCP wrapper for the 1inch v6 Aggregation API](https://github.com/sebastiancoombs/1inch-mcp) – Pay-per-call swap quotes, multi-token spot prices, and liquidity-source registry on 9+ EVM chains. Live: https://1inch-mcp.mtree.workers.dev
+- [coincap-mcp – x402 MCP wrapper for CoinCap v3](https://github.com/sebastiancoombs/coincap-mcp) – Pay-per-call real-time crypto market data: assets list, single-asset spot, historical OHLC, exchange directory. Live: https://coincap-mcp.mtree.workers.dev
+- [coinpaprika-mcp – x402 MCP wrapper for Coinpaprika](https://github.com/sebastiancoombs/coinpaprika-mcp) – Pay-per-call free crypto market data (no upstream API key): coin universe, live tickers, global market stats. Live: https://coinpaprika-mcp.mtree.workers.dev
+- [cryptocompare-mcp – x402 MCP wrapper for CryptoCompare min-api](https://github.com/sebastiancoombs/cryptocompare-mcp) – Pay-per-call multi-exchange crypto data: single price, multi-symbol prices, historical OHLCV bars. No upstream key on free-tier basics. Live: https://cryptocompare-mcp.mtree.workers.dev
+- [messari-mcp – x402 MCP wrapper for Messari](https://github.com/sebastiancoombs/messari-mcp) – Pay-per-call institutional crypto research API: asset profiles, current market metrics, latest news. Live: https://messari-mcp.mtree.workers.dev
 
 
 ### Security & Ops


### PR DESCRIPTION
## What
Six new live x402 MCP services from Money Tree, all wrapping free/keyed crypto-market data APIs and accepting USDC on Base for pay-per-call:

| Service | Source API | Live URL | Endpoints |
|---|---|---|---|
| **0x-mcp** | 0x v2 Trading API | https://0x-mcp.mtree.workers.dev | `/v1/swap/price` ($0.01), `/v1/swap/quote` ($0.03), `/v1/sources` ($0.005) |
| **1inch-mcp** | 1inch v6 Aggregation API | https://1inch-mcp.mtree.workers.dev | `/v1/quote` ($0.02), `/v1/spot_price` ($0.005), `/v1/protocols` ($0.005) |
| **coincap-mcp** | CoinCap v3 | https://coincap-mcp.mtree.workers.dev | `/v1/assets` ($0.005), `/v1/asset` ($0.005), `/v1/asset_history` ($0.02), `/v1/exchanges` ($0.005) |
| **coinpaprika-mcp** | Coinpaprika v1 (no upstream key) | https://coinpaprika-mcp.mtree.workers.dev | `/v1/coins` ($0.005), `/v1/ticker` ($0.005), `/v1/global` ($0.005) |
| **cryptocompare-mcp** | CryptoCompare min-api (no upstream key on basics) | https://cryptocompare-mcp.mtree.workers.dev | `/v1/price` ($0.005), `/v1/multi_price` ($0.005), `/v1/ohlcv` ($0.02) |
| **messari-mcp** | Messari API v1 | https://messari-mcp.mtree.workers.dev | `/v1/asset_profile` ($0.02), `/v1/asset_metrics` ($0.05), `/v1/news` ($0.005) |

All six are deployed to Cloudflare Workers and return valid 402 envelopes (\`payTo: 0x1664530DC2A1CA350B1dbaD1Fc1F1a70c90fe4de\`, \`asset: USDC on Base\`, \`network: base\`) on the priced endpoints. No signup or buyer-side API key required.

## Discovery
Each service serves the standard well-knowns:
- A2A agent-card → \`/.well-known/agent-card.json\`
- MCP server-card → \`/.well-known/mcp.json\`
- OpenAI plugin → \`/.well-known/ai-plugin.json\`
- OpenAPI 3.1 → \`/openapi.yaml\`
- MCP Streamable HTTP transport → \`POST /mcp\`

## Why bundled
This batch was generated by the Money Tree x402-MCP factory in a single EXECUTE cycle (PRD-04, shotgun-mode). Bundling six related crypto-market wrappers in one PR reduces review overhead vs six near-identical PRs. Happy to split if you'd prefer one-per-service.