### PR TITLE
Add EconDash to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [EconDash](https://econdash.org) — Global macroeconomic data API with x402 pay-per-call access. 753 indicators across 298 countries via 15 endpoints (GDP, inflation, employment, trade). USDC settlement on Base with MPP support for Solana. ([OpenAPI](https://econdash.org/m2m-openapi.json)) ([Docs](https://econdash.org/docs/quick-start))
 
 
 ### Security & Ops


### PR DESCRIPTION
Add EconDash — a production macroeconomic data API for AI agents with x402 pay-per-call access.

- 753 indicators across 298 countries via 15 endpoints
- x402 USDC settlement on Base with MPP support for Solana
- OpenAPI spec: https://econdash.org/m2m-openapi.json
- Docs: https://econdash.org/docs/quick-start