### PR TITLE
Add x402agent.no — Norwegian business data & backlink APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
+- [x402agent.no](https://x402agent.no) - Norwegian business data (Brønnøysundregistrene) and SEO backlink analysis for AI agents. Pay-per-request USDC on Base, no API keys. ([x402 Discovery](https://x402agent.no/.well-known/x402.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adding [x402agent.no](https://x402agent.no) to the Ecosystem section.

Live x402-powered services on Base mainnet:
- **Norwegian Companies House** — Brønnøysundregistrene company search, ownership, financials
- **Backlink Finder (bhrefs)** — SEO domain crawl and referring page analysis

Discovery: https://x402agent.no/.well-known/x402.json
Agent docs: https://x402agent.no/llms.txt