### PR TITLE
Add x402 Foundation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Official Resources
 - [x402 Official Website](https://www.x402.org)
+- [x402 Foundation Docs](https://docs.x402.org/) - Credibly neutral documentation for the open x402 standard.
+- [x402 Foundation at the Linux Foundation](https://www.linuxfoundation.org/x402foundation)
 - [x402 Whitepaper (PDF)](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 Developer Docs Portal](https://docs.cdp.coinbase.com/x402/welcome)
 - [Coinbase Announcement – Introducing x402](https://www.coinbase.com/developer-platform/discover/launches/x402)
@@ -36,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Open Source & SDKs
 - [coinbase/x402 (GitHub)](https://github.com/coinbase/x402)
+- [x402-foundation/x402 (GitHub)](https://github.com/x402-foundation/x402) - Reference SDKs and examples maintained under the x402 Foundation.
 - [x402-rs (Rust Facilitator & SDK)](https://github.com/x402-rs/x402-rs)
 - [x402 TypeScript SDKs](https://github.com/coinbase/x402/tree/main/typescript)
 - [x402-analytics (NPM)](https://www.npmjs.com/package/x402-analytics) - Analytics wrapper for x402 payments with monitoring and insights.


### PR DESCRIPTION
Closes #10

## Summary
- add the current x402 Foundation docs link
- add the Linux Foundation x402 Foundation page
- add the x402 Foundation GitHub reference SDK repository

## Verification
- verified all three added links return HTTP 200 with `curl -I -L`