### PR TITLE
Add x402 extension and agent payment resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 #### Extensions
 - [ERC-3009 Forwarding](https://github.com/TheGreatAxios/eip3009-forwarder): forwarding contract extending meta-transactions with EIP-721 signatures to any ERC-20 on any network
+- [x402 Extensions Overview](https://docs.x402.org/extensions/overview): official guide to x402 resource server and facilitator extension points
+- [A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402): specification, libraries, and examples for adding on-chain x402 payments to Agent-to-Agent services
 
 ### Tutorials & Guides
 - [QuickNode – How to Implement a Crypto Paywall with x402](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
@@ -67,6 +69,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [MCP Server with x402 Guide](https://docs.cdp.coinbase.com/x402/mcp-server)
 - [Base AgentKit – Building Autonomous Agents with x402](https://docs.base.org/agentkit/x402)
 - [Vercel x402 MCP SDK Announcement](https://vercel.com/blog/introducing-x402-mcp-open-protocol-payments-for-mcp-tools)
+- [Cloudflare Agents x402 Docs](https://developers.cloudflare.com/agents/agentic-payments/x402/): official Cloudflare guide for charging and paying for resources with x402 in Agents
 - [How to Get Started with x402 on Solana](https://solana.com/developers/guides/getstarted/intro-to-x402) – Official Solana guide for integrating x402 payments on Solana networks.
 
 ### Example Apps


### PR DESCRIPTION
## Summary
- Add the official x402 Extensions overview to the Extensions section.
- Add the A2A x402 Extension resource for Agent-to-Agent payment flows.
- Add Cloudflare's official Agents x402 docs to Tutorials & Guides.

## Related
Contributes to #10.

## Validation
- `git diff --check`
- Verified these URLs return HTTP 200:
  - `https://docs.x402.org/extensions/overview`
  - `https://github.com/google-agentic-commerce/a2a-x402`
  - `https://developers.cloudflare.com/agents/agentic-payments/x402/`