### PR TITLE
Add HTTP 402 standard references

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 
 ### Standards and EIPs
+- [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.
+- [HTTP 402 Payment Required (IANA Registry)](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml): canonical HTTP status-code registry entry for 402.
 - [ERC-3009 — Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009): meta-transaction transfers using EIP-712 signatures, enabling gasless and recipient-submitted transfers.
 - [EIP-712 — Typed Structured Data Hashing and Signing](https://eips.ethereum.org/EIPS/eip-712): canonical typed signing used by modern wallets.
 - [EIP-2612 — permit for ERC-20](https://eips.ethereum.org/EIPS/eip-2612): approvals via signatures; often complementary to authorization-based flows.


### PR DESCRIPTION
Adds two authoritative HTTP 402 references to the Standards and EIPs section:

- MDN's HTTP 402 Payment Required reference
- IANA's canonical HTTP status-code registry entry for 402

These are useful baseline resources for x402 because the protocol standardizes payment flows around the HTTP 402 status code.

Closes #10