### PR TITLE
[codex] docs: add HTTP 402 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 
 ### Standards and EIPs
+- [HTTP 402 Payment Required — MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the HTTP status code x402 builds on.
 - [ERC-3009 — Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009): meta-transaction transfers using EIP-712 signatures, enabling gasless and recipient-submitted transfers.
 - [EIP-712 — Typed Structured Data Hashing and Signing](https://eips.ethereum.org/EIPS/eip-712): canonical typed signing used by modern wallets.
 - [EIP-2612 — permit for ERC-20](https://eips.ethereum.org/EIPS/eip-2612): approvals via signatures; often complementary to authorization-based flows.


### PR DESCRIPTION
## Summary

- Adds MDN's HTTP 402 Payment Required reference to the Standards and EIPs section.
- Keeps the link grouped with protocol/status-code context that x402 builds on.

## Validation

- Verified the MDN URL resolves successfully.
- Compared branch against `master`: 1 README line added.

Related to #10.