### PR TITLE
Add x402 AI starter resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Official Website](https://www.x402.org)
 - [x402 Whitepaper (PDF)](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 Developer Docs Portal](https://docs.cdp.coinbase.com/x402/welcome)
+- [x402 Docs llms.txt](https://docs.x402.org/llms.txt) - Machine-readable index of the x402 docs for AI agents and LLM-assisted integrations.
 - [Coinbase Announcement – Introducing x402](https://www.coinbase.com/developer-platform/discover/launches/x402)
 - [GitHub repo](https://github.com/coinbase/x402) — issues, proposals, and reference materials
   - [Issues](https://github.com/coinbase/x402/issues)
@@ -79,6 +80,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Example Gallery (GitHub)](https://github.com/coinbase/x402/tree/main/examples)
 - [x402 Analytics Examples](https://github.com/RemsLabs/x402-analytics-examples) - Practical examples demonstrating x402-analytics usage with buyer and seller implementations.
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
+- [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary
- add the x402 docs `llms.txt` index to Official Resources for LLM-assisted integrations
- add Vercel's x402 AI Starter template to Example Apps

## Bounty
Submission for the Merit `$5` resource issue: #10.
GitHub contributor to credit: @qingshanliuci.

## Verification
- `git diff --check`
- verified both added links return HTTP 200
