### PR TITLE
Add TrustBench (non-custodial routing and audit layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-analytics (NPM)](https://www.npmjs.com/package/x402-analytics) - Analytics wrapper for x402 payments with monitoring and insights.
 - [x402-Solana (Community)](https://github.com/8bitsats/x402-Solana)
 - [Pipegate (x402 + Payment Channels)](https://github.com/Dhruv-2003/pipegate)
+- [TrustBench](https://trustbench.io) - Non-custodial routing and audit layer on top of x402. Ed25519-signed receipts with on-chain settlement evidence, verifiable offline. Fail-safe paywall on Base via the Coinbase CDP facilitator. Verifier on npm: [`@trustbench/verify-receipt`](https://www.npmjs.com/package/@trustbench/verify-receipt).
 - [thirdweb/x402 (Github)](https://github.com/thirdweb-dev/js/tree/main/packages/thirdweb/src/x402)
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)
@@ -48,6 +49,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-mcp package (Vercel)](https://github.com/ethanniser/x402-mcp)
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
+
 
 
 ### Standards and EIPs


### PR DESCRIPTION
TrustBench is a non-custodial routing and audit layer for x402 that produces
signed evidence rather than opinion. Every paid /route call emits an Ed25519-signed
receipt covering the routing decision and the on-chain settlement reference,
verifiable offline against a published public key with no dependency on TrustBench
being online or honest.

The paywall is fail-safe by design: if the upstream merchant is non-conformant
or down, TrustBench refuses to charge rather than proceed, so the agent's wallet
nonce stays whole and money never moves on bad routes. Validated end-to-end in
production 2026-05-11 when an upstream merchant suspension caused the paywall to
correctly refuse the call.

Live in production on Base mainnet via the Coinbase CDP facilitator. Sample
receipt: https://trustbench.io/receipts/rcpt_01KQY7C44GAPSXZPFQYRZ1D10C (verifies
SIGNATURE VALID + ON-CHAIN VERIFIED with no override).

Verifier on npm: @trustbench/verify-receipt (third-party offline verification,
no dependency on TrustBench being online or honest).

Honest scope:
- Routes Base today; Solana endpoints in the registry, routing next sprint.
- Liveness telemetry, not a benchmark. Methodology at /methodology.
- Pay-to-list, never pay-to-rank.