### PR TITLE
[codex] Add CoinMarketCap x402 API resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Example Apps
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
+- [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
## Summary
- Add CoinMarketCap x402 API docs to the Example Apps section.
- The resource covers pay-per-request crypto market data and an x402 MCP endpoint using USDC settlement on Base.

## Related
Contributes to Merit-Systems/awesome-x402#10.

## Validation
- `git diff --check`
- `curl -I -L --max-time 20 https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402` returned HTTP 200.