### PR TITLE
Add OpenZeppelin x402 facilitator resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Adds OpenZeppelin's Relayer x402 Facilitator guide to the Facilitators & Networks section.\n\nThe resource documents a Stellar x402 facilitator plugin for payment verification and settlement using OpenZeppelin Relayer, including setup, plugin configuration, supported endpoints, and example integration with x402 packages.\n\nVerification:\n- checked the README for existing OpenZeppelin/x402 facilitator entries\n- verified the linked OpenZeppelin docs page is live\n\nRefs #10