### PR TITLE
Add official x402 v2 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Whitepaper (PDF)](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 Developer Docs Portal](https://docs.cdp.coinbase.com/x402/welcome)
 - [Coinbase Announcement – Introducing x402](https://www.coinbase.com/developer-platform/discover/launches/x402)
+- [x402 V2 Launch Note](https://www.x402.org/writing/x402-v2-launch) - official overview of the v2 protocol changes, including modular SDKs, CAIP identifiers, and expanded payment flows.
 - [GitHub repo](https://github.com/coinbase/x402) — issues, proposals, and reference materials
   - [Issues](https://github.com/coinbase/x402/issues)
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
@@ -28,7 +29,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
--- [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)
+- [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
@@ -64,6 +65,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Circle Blog – Autonomous Payments using Circle Wallets, USDC, and x402](https://www.circle.com/blog/autonomous-payments-using-circle-wallets-usdc-and-x402)
 - [x402 Quickstart for Sellers](https://docs.cdp.coinbase.com/x402/quickstart-for-sellers)
 - [x402 Quickstart for Buyers](https://docs.cdp.coinbase.com/x402/quickstart-for-buyers)
+- [x402 Migration Guide (v1 to v2)](https://docs.cdp.coinbase.com/x402/migration-guide) - official upgrade guide covering header changes, CAIP-2 network IDs, and current v2 SDK package mappings.
 - [MCP Server with x402 Guide](https://docs.cdp.coinbase.com/x402/mcp-server)
 - [Base AgentKit – Building Autonomous Agents with x402](https://docs.base.org/agentkit/x402)
 - [Vercel x402 MCP SDK Announcement](https://vercel.com/blog/introducing-x402-mcp-open-protocol-payments-for-mcp-tools)


### PR DESCRIPTION
Addresses #10.

## Summary
- Add the official x402 V2 launch note to Official Resources.
- Add the official x402 v1-to-v2 migration guide to Tutorials & Guides.
- Fix the malformed Supported Networks Markdown bullet while touching the same resource area.

## Validation
- Checked both added links return HTTP 200.
- Reviewed the README to confirm these resources were not already listed.