### PR TITLE
Add x402 protocol and Stellar resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Official Resources
 - [x402 Official Website](https://www.x402.org)
+- [x402 Protocol Docs](https://docs.x402.org/introduction)
 - [x402 Whitepaper (PDF)](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 Developer Docs Portal](https://docs.cdp.coinbase.com/x402/welcome)
 - [Coinbase Announcement – Introducing x402](https://www.coinbase.com/developer-platform/discover/launches/x402)
@@ -28,7 +29,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
--- [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)
+- [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)
+- [x402 on Stellar](https://developers.stellar.org/docs/build/agentic-payments/x402) - Stellar payment flow, compatible wallets, and facilitator options for x402 payments.
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)


### PR DESCRIPTION
## Summary
- Add the official x402 protocol docs entry to Official Resources
- Add Stellar's x402 documentation to Facilitators & Networks
- Fix a malformed Markdown bullet in the facilitator list

## Verification
- git diff --check
- Confirmed x402 protocol docs URL returns HTTP 200

Addresses #10