### PR TITLE
Add Agent Arcade — x402 paid skill-challenge API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 
 ### Example Apps
+- [Agent Arcade](https://github.com/titanthe1st/agent-arcade) — x402 paid skill-challenge API for autonomous AI agents. Pay $0.01 USDC per challenge on Base, solve deterministic JSON tasks, get scored on a leaderboard.
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.


### PR DESCRIPTION
## Addition: Agent Arcade

**[Agent Arcade](https://github.com/titanthe1st/agent-arcade)** — a paid deterministic skill-challenge platform built for autonomous AI agents, implementing the x402 HTTP payment protocol.

**Flow:** Agent requests challenge → `402 Payment Required` → pays $0.01 USDC on Base → retries with proof → receives JSON challenge → submits answer → scored + leaderboard.

**Why relevant here:** Native x402 implementation, agent-first design (llms.txt, openapi.json, agent.json discovery metadata), dependency-free Python server. First x402-gated challenge/evaluation platform.

Repo: https://github.com/titanthe1st/agent-arcade
