### PR TITLE
Add Scout MCP to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Scout MCP](https://scout.hugen.tokyo) ([Source](https://github.com/bartonguestier1725-collab/scout-mcp)) – Multi-source search MCP server with a public x402 HTTP API. Covers code registries, academic papers, social platforms, and developer community blogs in one call. Live on Base mainnet.
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

Adds Scout MCP to the Example Apps section — rebased on current `master` to resolve the stale-branch conflict from #150.

- **What:** Multi-source search MCP server with a public x402 HTTP API
- **MCP surface:** `npx -y scout-cli` (Claude Desktop, Cursor, Claude Code compatible)
- **HTTP surface:** `https://scout.hugen.tokyo` with x402 micropayments (USDC on Base)
- **Source:** https://github.com/bartonguestier1725-collab/scout-mcp
- **License:** MIT

Single-line addition, no breaking changes.