### PR TITLE
feat(facilitators): add AlgoVoi multi-protocol facilitator (8 networks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [PayAI Facilitator & Supported Networks](https://docs.payai.network/x402/quickstart#facilitator)
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [AlgoVoi Multi-Protocol Facilitator (7 networks)](https://docs.algovoi.co.uk/concepts/xchain) - x402 + MPP + AP2 facilitator covering Base, Solana, Stellar, Algorand, VOI, Hedera, and Tempo. xChain bridges EVM USDC to Solana (Circle CCTP V2, ~50s), Stellar (Allbridge Core, classic Circle USDC at issuer GA5ZSEJ…), and Algorand from MetaMask without a destination wallet.
+  - [Live `pay.sh`-compatible catalog](https://api.algovoi.co.uk/.well-known/pay-skills.json)
+  - [Discovery (a2a / x402)](https://api.algovoi.co.uk/.well-known/agent-card.json)
 
 
 ### Open Source & SDKs

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Satoshi Facilitator](https://facilitator.bitcoinsapi.com/supported) - Independent x402 facilitator for Bitcoin-focused pay-per-call services with Base, Base Sepolia, Solana Mainnet, and Solana Devnet support.
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
+- [AlgoVoi Multi-Protocol Facilitator (8 networks)](https://docs.algovoi.co.uk/introduction) - x402 + MPP + AP2 facilitator covering Base, Solana, Stellar, Algorand, VOI, Hedera, Tempo, and ARC. xChain bridges EVM USDC to Solana (Circle CCTP V2, ~50s), Stellar (Allbridge Core, classic Circle USDC at issuer GA5ZSEJ…), and Algorand from MetaMask without a destination wallet.
+  - [Live `pay.sh`-compatible catalog](https://api.algovoi.co.uk/.well-known/pay-skills.json)
+  - [Discovery (a2a / x402)](https://api.algovoi.co.uk/.well-known/agent-card.json)
 - [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
 
 


### PR DESCRIPTION
## What this adds

A single bullet under **Facilitators & Networks** for AlgoVoi — a multi-protocol (x402 + MPP + AP2 + A2A) facilitator covering **8 mainnet networks**: Base, Solana, Stellar, Algorand, VOI, Hedera, Tempo, and ARC.

## Why it fits

- **Broadest network coverage** in the facilitators section: the only entry supporting Stellar, Algorand, VOI, Hedera, Tempo, and ARC behind a single x402 endpoint.
- **xChain bridge UX** — agents holding USDC on any of 7 EVM source chains (Base, Arbitrum, Polygon, Optimism, Ethereum, BNB, Avalanche) can pay AlgoVoi-protected resources from MetaMask without a destination-chain wallet.
  - Solana: Circle CCTP V2 (~50s native USDC)
  - Stellar: Allbridge Core → canonical Circle USDC at issuer `GA5ZSEJ…`
  - Algorand: deterministic LogicSig pattern
- **Compliance-aware**: open attestation at `GET /compliance/attestation` and pre-payment screening — the first Bazaar-listed facilitator with built-in AML gates.
- **pay.sh-compatible catalog** — AlgoVoi is listed in the Solana Foundation pay-skills registry.

## Live verification

```sh
# 402 probe — returns multi-chain accepts[]
curl -sI https://api.algovoi.co.uk/mpp/probe | grep -i payment

# pay.sh catalog
curl -s https://api.algovoi.co.uk/.well-known/pay-skills.json | jq '{version, base_url}'
```

Happy to address any feedback.