### PR TITLE
Add GetMyCert to the ecosystem list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
+- [GetMyCert](https://getmycert.com/developers) - 13,072 IT certification practice questions (AWS, CompTIA, Azure, GCP, Cisco, 27 certs) via x402 micropayments on Base mainnet. $0.01–0.04 USDC per batch, no API key, no signup. MCP server: [Smithery](https://smithery.ai/server/getmycert-questions). Discovery: [x402.json](https://getmycert.com/.well-known/x402.json)
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) - Free public leaderboard of every paid x402 service indexed via the Coinbase CDP discovery API. Refreshed every 15 min, four views (top by volume / unique payers / recently active / cheapest), JSON variant at `/bazaar.json`. Complementary CDP-only slice next to x402Scan's multi-source view.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)


### PR DESCRIPTION
Adds GetMyCert to the Ecosystem section.

GetMyCert provides 13,072 IT certification practice questions (AWS, CompTIA, Azure, GCP, Cisco, 27 certs) payable via x402 micropayments on Base mainnet. $0.01–0.04 USDC per batch, no API key, no signup required.

- Live endpoint: https://getmycert.com/developers
- - x402 discovery: https://getmycert.com/.well-known/x402.json
- - MCP server on Smithery: https://smithery.ai/server/getmycert-questions