### PR TITLE
Add klymax402 to Ecosystem (100 x402 APIs for agentic payments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
+- [klymax402](https://klymax402.com) - 100 x402-native APIs spanning email/SEO/web scraping/wallet/DEX/Hyperliquid/NFT/ENS. Pure USDC micropayments on Base L2, no signup. Public catalog at [/llms.txt](https://klymax402.com/llms.txt); every endpoint also exposes `/mcp` for MCP SSE clients.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))


### PR DESCRIPTION
Adds **klymax402** to the ecosystem section.
  
  100 x402-enabled APIs across email, SEO, web scraping, wallet, DEX,
  Hyperliquid, NFT, ENS, crypto news, utility. All endpoints respond
  `HTTP 402` with x402 v2 challenge format (`accepts[]` array + base64
  `payment-required` header), USDC settlement on Base L2 (`eip155:8453`)
  via Coinbase CDP facilitator.

  **Technical**
  - Hosted on Hetzner (Caddy + 100 Bun services), wildcard TLS `*.api.klymax402.com`
  - MCP SSE transport on each `/mcp` endpoint
  - Catalog (machine-readable): https://klymax402.com/llms.txt
  - Source: https://github.com/Br0ski777 (repos named `*-x402`)

  **Verification**
  curl -X POST https://email-verification.api.klymax402.com/api/verify
  → HTTP 402 + base64 payment-required header