### PR TITLE
Add AI Talent Atlas to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AI Talent Atlas](https://www.agentrift.tech) - Pay-per-request API for AI researcher intelligence. 643 researchers across 14 major labs with h-index, citations, co-author networks, talent flow, and departure tracking. USDC on Base via xpay.sh facilitator.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds AI Talent Atlas — a pay-per-request data API for AI researcher intelligence.

- **643 researchers** across **14 labs** (OpenAI, Anthropic, DeepMind, Meta, etc.)
- h-index, citations, co-author networks, talent flow matrix, departure tracking
- 8 paid endpoints ($0.01–$0.50 USDC) on Base via xpay.sh facilitator
- Website: https://www.agentrift.tech
- GitHub: https://github.com/FuturMix/ai-talent-x402-api