### PR TITLE
Add x402trace under Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 
 - [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
+- [x402trace](https://github.com/fardinvahdat/x402trace) — Local CLI debugger for x402 on Base. Detects timeout-reconciliation gaps (the [#1062](https://github.com/coinbase/x402/issues/1062) settled-but-server-thinks-not pattern), validates `.well-known/x402` + Bazaar listings (the [#2207](https://github.com/x402-foundation/x402/issues/2207) cluster), diffs facilitators in parallel, and explains 402s offline with 15 diagnostic rules. Read-only, no key handling. Sepolia + Base mainnet. ([npm](https://www.npmjs.com/package/x402trace))
 ### Standards and EIPs
 - [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.
 - [HTTP 402 Payment Required (IANA Registry)](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml): canonical HTTP status-code registry entry for 402.


### PR DESCRIPTION
Adding [x402trace](https://github.com/fardinvahdat/x402trace) under `### Open Source & SDKs`.

## What it is

A local CLI debugger for x402 on Base. Read-only, no key handling.

- **`x402trace proxy --reconcile`** — detects the [#1062](https://github.com/coinbase/x402/issues/1062) "settled-but-server-thinks-not" timeout-reconciliation gap by joining local proxy logs with Base USDC `Transfer` events.
- **`x402trace bazaar-check`** — validates `.well-known/x402` shape + `extensions.bazaar` + indexing query; emits a single verdict for the [#2207](https://github.com/x402-foundation/x402/issues/2207) cluster (is the bug yours, or upstream?).
- **`x402trace validate [--diff]`** — pre-flight wallet against a service's 402 challenge; with `--diff` runs the same payload through multiple facilitators (CDP, xpay, x402.org, PayAI) in parallel and surfaces drift.
- **`x402trace explain`** — plain-English diagnosis of a captured JSONL log, 15 diagnostic rules.

Verified against live Base Sepolia (three independent on-chain reconciliations).

## Links

- npm: https://www.npmjs.com/package/x402trace
- repo: https://github.com/fardinvahdat/x402trace
- v0.3.0 release: https://github.com/fardinvahdat/x402trace/releases/tag/v0.3.0

## Placement rationale

Sits naturally in the SDKs & open-source CLI cluster (alongside `x402-proxy`, `agenticpay` CLI, etc) — npm-installable, local, MIT-equivalent license (Apache-2.0).