### PR TITLE
Add Fleet x402 Microservices — live agent-payable services on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [Fleet x402 Microservices](https://fleet-x402-audit.fly.dev) - Live agent-payable services on Base: SEO Audit ($0.05 USDC) and Competitive Intel Pack ($0.50 USDC). Instant JSON response, discoverable via `/.well-known/x402-listing`.
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.


### PR DESCRIPTION
## What this adds

[Fleet x402 Microservices](https://fleet-x402-audit.fly.dev) — two production x402 services live on Base mainnet:

| Service | Endpoint | Price |
|---------|----------|-------|
| SEO Audit | `POST /audit` | $0.05 USDC |
| Competitive Intel Pack | `POST /intel-pack` | $0.50 USDC |

**Discovery**: https://fleet-x402-audit.fly.dev/.well-known/x402-listing

- Network: Base, asset: USDC
- Scheme: `exact`, immediate response
- Agent-native: no API key, payment-gated only