### PR TITLE
Add 3 paid x402 services on Base: unlock, pricing-matrix, bill-negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [unlock-api](https://unlock-api.lewis-6d8.workers.dev) — Pay-per-unlock website fetcher; `POST /unlock` returns rendered body, screenshot, or XHR capture through a stealth browser + residential proxy. Only charges on successful unlock (`expect_status` / `expect_contains` check). $0.02 USDC per call on Base.
+- [pricing-matrix-api](https://pricing-matrix-api.lewis-6d8.workers.dev) — SaaS pricing page extractor; `POST /compare` returns a normalized tier matrix as JSON. 24h KV cache per URL. $0.10 USDC per call on Base.
+- [bill-negotiation-api](https://bill-negotiation-api.lewis-6d8.workers.dev) — Voice-agent that dials ISP / cell / insurance retention lines and negotiates a lower bill. `POST /negotiate`, flat $20 USDC per attempt on Base.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adding three production x402 endpoints I built on Hono + Cloudflare Workers, all settling USDC on Base mainnet via the Coinbase CDP facilitator. All three are no-API-key, no-signup, pay-per-request.

- **unlock-api** ($0.02/call) — POST a URL, get rendered HTML / screenshot / XHR capture. Worker only settles payment when the page passes the caller's verification check.
- **pricing-matrix-api** ($0.10/call) — POST a SaaS pricing page, get a normalized tier matrix as JSON. 24h cache per URL.
- **bill-negotiation-api** ($20/call) — voice-agent that calls retention lines and negotiates a lower bill.

Added under Example Apps since the closest existing section is one-line bullets of paid endpoints.

payTo: `0x126de3e7992D443D24b542991122F2752AEF9da3` (Base mainnet USDC).