### PR TITLE
Add Routeweiler Python SDK to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-rails (QuickNode)](https://github.com/quiknode-labs/x402-rails) - Ruby gem for integrating blockchain micropayments into your Ruby on Rails application
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 - [MoltPe (AI agent payment infrastructure)](https://github.com/umangbuilds/moltpe-agent-payments) - Non-custodial agent wallets with Shamir key splitting, programmable spending policies, and tri-rail support: x402 (HTTP-native), MPP (session-based), and fiat. 11 MCP tools for Claude Desktop, Cursor, Windsurf. Sub-second settlement on Polygon PoS, Base, Tempo. Free tier, no credit card. ([Site](https://moltpe.com))
+- [Routeweiler](https://github.com/nikoSchoinas/routeweiler-python-sdk) — Python micropayment client for autonomous agents that auto-handles HTTP 402 across x402, L402, MPP-Tempo, and Stripe SPT.
 
 
 


### PR DESCRIPTION
Routeweiler is a non-custodial Python client that transparently handles HTTP 402 across four payment rails (x402, L402, MPP-Tempo, MPP-SPT) with a single `httpx`-compatible async API.

- PyPI: https://pypi.org/project/routeweiler/
- Repo: https://github.com/nikoSchoinas/routeweiler-python-sdk
- Docs: https://docs.routeweiler.com
- License: Apache-2.0

Happy to adjust the description, section placement, or formatting if the list maintainers prefer a different style.