### PR TITLE
Add YIELD INTELLIGENCE — x402 MCP server for passive income analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,4 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 This list is offered under CC0; see upstream specs for their respective licenses.
 
 - [AgentBridge](https://github.com/tianzizhiming-svg/agentbridge) — Pay-per-fetch gateway for Chinese web content (Xiaohongshu, Zhihu, etc.). Returns clean markdown, settled in USDC on Base via x402.
+- [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) — Passive income analysis MCP server with live US Treasury rates, portfolio yield calculator, and AI income optimizer. $1 USDC per call on Base via x402. Open MCP endpoint, no auth required. Also in the [official MCP Registry](https://registry.modelcontextprotocol.io/).


### PR DESCRIPTION
Adding YIELD INTELLIGENCE as an x402-enabled MCP server.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization for autonomous agents.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

x402 pricing: $1 USDC per call on Base

Tools: analyze_yield_opportunities, optimize_income_portfolio
