### PR TITLE
Update README.md - feat(ecosystem): add AgentTrust — security scanner + ERC-8257 Tool #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
+- [AgentTrust](https://agenttrust.uk) - Security scanner and reputation oracle for AI agent skills. Scans OpenClaw SKILL.md files for malware, prompt injection, and 37 other threat patterns. Free endpoint reputation checker and SVG trust badges. Registered as Tool #5 on ERC-8257 Agent Tool Registry.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))


### PR DESCRIPTION
AgentTrust is a security scanner and reputation oracle for AI agent skills, built natively on x402.

- Scans OpenClaw SKILL.md files for malware, prompt injection, and 37 other threat patterns
- Free endpoint reputation checker: GET https://agenttrust.uk/v1/reputation?url=YOUR_ENDPOINT
- SVG trust badges for x402 providers
- Registered as Tool #5 on ERC-8257 Agent Tool Registry on Base mainnet
- Free tier available, paid full scan $0.015 USDC via x402

Live: https://agenttrust.uk
GitHub: https://github.com/poteshniy/agenttrust