### PR TITLE
Update TerraDeed entry to include /extract endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
-
+- [TerraDeed Labs](https://api.terradeed.co.uk) - Pay-per-use web scraping and structured data extraction for AI agents. `/scrape` returns LLM-ready markdown ($0.01 USDC), `/extract` returns schema-driven structured JSON ($0.05 USDC). Supports JS-rendered SPAs via Playwright. Base mainnet.
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)


### PR DESCRIPTION
Updates the TerraDeed Labs entry to reflect the current API. Two endpoints now live: /scrape (LLM-ready markdown, $0.01 USDC) and /extract (schema-driven structured JSON, $0.05 USDC). Both tested with real on-chain payments on Base mainnet.