### PR TITLE
Add StockWaves to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
-- [StockWaves](https://stockwaves.net) - Pay-per-call quant signals for AI agents across equities (China A-share/HK/US), crypto (BTC), and cross-asset ETF macro. x402 on Base via Circle Gateway; OpenAPI + `/.well-known/x402` discovery; listed on x402Scan.
+- [StockWaves](https://stockwaves.net) - Pay-per-call quant signals & structured market intelligence for AI agents across equities (China A-share/HK/US), crypto (BTC signal + perp microstructure), cross-asset ETF macro, and structured Chinese-market news/events. x402 on Base via Circle Gateway; OpenAPI + `/.well-known/x402` discovery; listed on x402Scan.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [StockWaves](https://stockwaves.net) - Pay-per-call quant signals for AI agents across equities (China A-share/HK/US), crypto (BTC), and cross-asset ETF macro. x402 on Base via Circle Gateway; OpenAPI + `/.well-known/x402` discovery; listed on x402Scan.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **StockWaves** to the Ecosystem list.

Pay-per-call quant signals for AI agents across equities (China A-share/HK/US), crypto (BTC), and cross-asset ETF macro. x402 on Base mainnet via Circle Gateway, with OpenAPI + `/.well-known/x402` discovery. Already indexed on x402Scan.

- Site: https://stockwaves.net
- Discovery: https://stockwaves.net/.well-known/x402 · OpenAPI: https://stockwaves.net/openapi.json