### PR TITLE
Add Lithium Research Vault to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Lithium Research Vault](https://agentic.market/services/clink-lithium-vault-fly-dev) - Primary-source lithium-mining data API for AI agents. Structured production, AISC, reserves, ownership, royalties, and offtakes for 40 operators and 49 producing mines — extracted from SEC/ASX/TSX/SEDAR/cninfo filings and FX-normalized to USD, every figure traceable to a primary filing. Three x402 tiers on Base: $0.02 headline snapshot, $0.05 full rows, $0.20 cited narrative.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Lithium Research Vault** to the Ecosystem section — a live, primary-source lithium-mining data API for AI agents, monetized via x402 (USDC on Base).

- **Listed on agentic.market** with three tiers: `/vault/summary` ($0.02 headline snapshot), `/vault` ($0.05 full structured rows), `/vault/story` ($0.20 cited narrative synthesis).
- Covers 40 operators and 49 producing mines. Every figure is extracted from primary regulator filings (SEC/ASX/TSX/SEDAR/cninfo), FX-normalized to USD, and traceable to its source document.
- Grouped under the existing **Ecosystem** section alongside other live services. Single-line addition, primary source.
