### PR TITLE
Add TensorFeed to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [TensorFeed](https://tensorfeed.ai) - AI ecosystem data hub for agents: real-time AI news, model pricing, service status, research, and security feeds served as pay-per-call x402 endpoints (USDC on Base) with signed agent-fair-trade receipts, plus an MCP server and a free HuggingFace dataset.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds TensorFeed to the Ecosystem section.

[TensorFeed](https://tensorfeed.ai) is an AI ecosystem data hub for agents. It serves real-time AI news, model pricing, service status, research, and security feeds as pay-per-call x402 endpoints on Base (USDC), returns signed agent-fair-trade receipts on paid calls, and also ships an MCP server (@tensorfeed/mcp-server) plus a free HuggingFace dataset. Live x402 endpoints and free tiers are documented at https://tensorfeed.ai/developers/agent-payments.