### PR TITLE
Add ApexScout Agent Listing Roast

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
+- [ApexScout Agent Listing Roast](https://apexscout.ai/agent-listing-roast) - $1 Base mainnet x402 route and MCP-visible tool for builders to critique paid agent/API listing copy, buyer-agent skip reasons, and stop-or-upgrade guidance.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
 
 


### PR DESCRIPTION
## Add ApexScout Agent Listing Roast

**What:** Adds ApexScout Agent Listing Roast to the example apps section.

**Why:** It is a live Base mainnet x402 route for builders improving paid agent/API listing conversion, with MCP-visible tool metadata and a $1 pay-per-call API path.

**Checks:**
- [x] Public page returns HTTP 200
- [x] Protected API returns HTTP 402 with $1 x402 requirement
- [x] MCP metadata includes the paid route
- [x] Follows the existing README list format
