### PR TITLE
Add TWZRD Agent Intelligence to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [TWZRD Agent Intelligence](https://intel.twzrd.xyz) - Portable trust + receipt layer for x402 agents on Solana: a free preflight ReadinessCard scores any resource on a wash/Sybil-resistant cross-facilitator corpus, then a paid 0.05 USDC endpoint returns an Ed25519-signed V5 receipt verifiable offline. Live on mainnet, indexed on x402scan, with an [MCP server](https://pypi.org/project/twzrd-agent-intel/) on the official MCP Registry.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **TWZRD Agent Intelligence** to the Ecosystem section.

A portable **trust + receipt layer** for x402 agents on Solana:
- Free preflight **ReadinessCard** scores any resource on a wash/Sybil-resistant cross-facilitator reputation corpus (decide before you pay).
- Paid `GET /v1/intel/trust/{pubkey}` (0.05 USDC, Solana mainnet) returns the counterparty's trust score **and** a portable Ed25519-signed **V5 receipt** verifiable offline (no trust in our server).

Live on mainnet at https://intel.twzrd.xyz, indexed on x402scan, with an MCP server on the official MCP Registry (`io.github.twzrd-sol/twzrd-agent-intel`, `pip install twzrd-agent-intel`). Fits alongside the reputation/identity entries (AgentZone, Pyrimid, Strale).