### PR TITLE
Add PipRail (backendless multi-chain x402 SDK) to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 
 - [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
+- [PipRail](https://github.com/piprail/piprail) - Backendless, MIT TypeScript SDK for x402 across 28 chains in 10 families (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL). No facilitator, no fee — payments settle straight to your wallet, verified locally against your own RPC. ([npm](https://www.npmjs.com/package/@piprail/sdk))
 ### Standards and EIPs
 - [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.
 - [HTTP 402 Payment Required (IANA Registry)](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml): canonical HTTP status-code registry entry for 402.


### PR DESCRIPTION
Adds **PipRail** to the *Open Source & SDKs* list.

PipRail (`@piprail/sdk`) is a backendless, MIT-licensed TypeScript SDK for x402 across **28 chains in 10 families** (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL) — **no facilitator, no fee**; payments settle straight to the developer's wallet, verified locally against their own RPC (merchant-local verification per x402 v2 §7).

- Repo: https://github.com/piprail/piprail
- npm: https://www.npmjs.com/package/@piprail/sdk
- Site: https://piprail.com