### PR TITLE
Add Paddock to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Paddock](https://paddock.finance) - Market intelligence terminal for AI agent commerce ("Bloomberg for the x402 economy"). Tracks daily transaction volume, USDC spend, unique buyer agents, active providers, and per-service liveness across x402, MCP, and TrustBench probe data. Six tools for cheapest-live-provider routing, pre-payment liveness checks, and niche-gap discovery via REST, [MCP server](https://paddock.finance/docs), or x402 per-query on Base.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Paddock is a market intelligence terminal for AI agent commerce, tracking volume, USDC spend, buyer agents, and per-service liveness across x402, MCP, and TrustBench. Grouped under Ecosystem alongside other analytics/explorer tools.