### PR TITLE
Add img402 to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [img402](https://img402.dev) - Image hosting for AI agents, paid via x402. Upload an image, get a public CDN-backed URL. Free tier (1MB, 7-day) plus $0.01 (1-year) and $1 (permanent) tiers in USDC on Base and Solana via the Coinbase CDP facilitator. No API keys or signup. ([Docs](https://img402.dev/docs) | [OpenAPI](https://img402.dev/openapi.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [img402](https://img402.dev) to the Ecosystem section.

img402 is a live x402-native image hosting service for AI agents: upload an image, pay via x402, get a public CDN-backed URL. Free tier (1MB, 7-day retention) plus $0.01 (1-year) and $1 (permanent) paid tiers, USDC on Base and Solana via the Coinbase CDP facilitator. No API keys or signup.

It's indexed in the CDP Bazaar and visible on [x402scan](https://x402scan.com) (ownership-verified). Agent discovery surfaces: [openapi.json](https://img402.dev/openapi.json), [llms.txt](https://img402.dev/llms.txt), `/.well-known/agent.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)