### PR TITLE
add Phoenix Zero x402 L2 sequencer health oracle to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Phoenix Zero](https://rtt.phoenix-ai.work) - Production L2 sequencer health oracle continuously probing Base, Arbitrum, Optimism, and ZKSync RTT every 2 seconds since March 2026 (200k+ records). Detects MEV wars 27s–3min ahead of on-chain revert spikes. The `/v1/safe` endpoint returns `{"safe":true/false,"reason":"..."}` via x402 at $0.001 USDC per call on Base mainnet — ROI ~2,300× vs wasted gas during a typical MEV storm (72% revert event, May 2026). Free delayed feed at [`/api/public-feed`](https://rtt.phoenix-ai.work/api/public-feed).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
## What this adds

**[Phoenix Zero](https://rtt.phoenix-ai.work)** — production L2 sequencer health oracle running since March 2026.

### What it does
- Probes Base, Arbitrum, Optimism, ZKSync RTT every 2 seconds (200k+ records)
- Detects MEV wars **27s–3 minutes ahead** of on-chain revert spikes (documented events May–June 2026)
- `/v1/safe` returns `{"safe":true/false,"reason":"..."}` — designed for AI agent pre-flight checks

### x402 details
- Price: **$0.001 USDC** per call
- Network: Base mainnet
- Facilitator: Coinbase CDP (`api.cdp.coinbase.com/platform/v2/x402`)
- Free delayed feed: https://rtt.phoenix-ai.work/api/public-feed

### Evidence
- 72.1% arb_revert_ratio event (May 31, 2026) with 3-min lead time detected by RTT probe
- ROI ~2,300x vs wasted gas on reverts during MEV storm ($0.003 for 3 checks vs $7 wasted)

Fits in **Ecosystem** section alongside other production x402 data services.
