### PR TITLE
Add n0brains — agent-native crypto intelligence (x402 + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [n0brains](https://n0brains.com) - Agent-native crypto intelligence with a public, auditable win-rate ([/proof](https://n0brains.com/proof)). Pay-per-call x402 endpoints on Base ($0.005/signal, USDC, no account), hosted MCP server (23 tools), and a stdlib-only Python CLI. Discovery: [/.well-known/x402.json](https://api.n0brains.com/.well-known/x402.json)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [n0brains](https://n0brains.com) — crypto intelligence API that publishes a live, auditable per-signal-type win-rate at [n0brains.com/proof](https://n0brains.com/proof). x402 pay-per-call live on Base (discovery at `/.well-known/x402.json`), hosted MCP server with 23 read-only tools, CLI on PyPI (`n0brains-cli`). All claims verifiable from the linked endpoints.