### PR TITLE
Add x402 Spend Receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [x402 Spend Receipt](https://github.com/selfradiance/x402-spend-receipt) - Local policy gate for x402 payment intents: deterministic spend rules with Ed25519-signed, hash-chained allow/deny receipts and machine-readable reason codes. MIT, no custody, no network calls.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds x402 Spend Receipt: a local, MIT-licensed policy gate that produces Ed25519-signed, hash-chained allow/deny receipts for x402 payment intents. Repo: https://github.com/selfradiance/x402-spend-receipt | npm: x402-spend-receipt.