### PR TITLE
Add x402 Video to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [x402 Video](https://x402-video.com) - Pay-per-call AI video generation (Seedance family) over x402: HTTP 402 → pay USDC on Base → MP4. No accounts or API keys; prompts are screened before payment and rejected requests are never charged. Agent storefront at [llms.txt](https://api.x402-video.com/llms.txt), live reliability stats at [/status](https://api.x402-video.com/status).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
## Summary

Adds **[x402 Video](https://x402-video.com)** to the Ecosystem section — pay-per-call AI video generation (Seedance family) sold over x402. `HTTP 402 → pay USDC on Base → MP4`, no accounts or API keys.

- Live on Base mainnet, settling via the Coinbase CDP facilitator
- Prompts are screened before payment — rejected requests are never charged
- Agent-readable storefront: [llms.txt](https://api.x402-video.com/llms.txt) · machine-readable SKUs at [`GET /`](https://api.x402-video.com/) · public reliability stats at [/status](https://api.x402-video.com/status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)