### PR TITLE
Add x402 Paid Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
+- [x402 Paid Endpoint](https://github.com/selfradiance/x402-paid-endpoint) - Live $1 USDC endpoint on Base mainnet selling a machine-readable artifact via x402 v2 'exact'. MIT, includes a reference buyer gated by a local signed-receipt policy layer (x402-spend-receipt). First purchase settled on-chain with zero human involvement. [Live](https://x402-paid-endpoint.selfradiance.workers.dev)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
 
 


### PR DESCRIPTION
This adds my project, x402 Paid Endpoint, to the Example Apps section. It is a live $1 USDC endpoint on Base mainnet that sells a machine-readable artifact via x402 v2 exact, is MIT licensed, and includes a reference buyer gated by x402-spend-receipt.

Repo: https://github.com/selfradiance/x402-paid-endpoint
Endpoint: https://x402-paid-endpoint.selfradiance.workers.dev
