### PR TITLE
Add Crypto Data Agent to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
+- [Crypto Data Agent](https://x402-crypto-data.vercel.app) - Live crypto prices and DeFi yield pools for AI agents at -e.002 USDC per call, dual-rail x402 payments on Base and Solana mainnet, Bazaar-listed, free sample endpoint. [MCP server](https://github.com/MooneyLive/crypto-data-x402-mcp) available.
+
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)


### PR DESCRIPTION
Adds **Crypto Data Agent** to Ecosystem: live coin prices + DeFi yield pools (APY/TVL filters) for agents, $0.002 USDC/call, dual-rail x402 on Base and Solana mainnet (CDP facilitator, Bazaar v2 discovery extension), free sample endpoint, MCP server for Claude/Cursor.
