### PR TITLE
Add Forge Cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Forge Cascade](https://forgecascade.org/) - Experimental institutional memory and knowledge graph platform with public x402 discovery metadata, payment OpenAPI docs, MCP, and A2A agent surfaces for Base USDC agent-commerce workflows. ([x402 discovery](https://forgecascade.org/.well-known/x402) | [Payment OpenAPI](https://forgecascade.org/openapi.payments.json) | [Agent card](https://forgecascade.org/.well-known/agent-card.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
﻿## What

Adds Forge Cascade to the ecosystem section as an experimental x402/A2A/MCP resource.

## Why

Forge exposes public x402 discovery metadata, payment OpenAPI docs, MCP, and A2A surfaces for Base USDC agent-commerce workflows.

## Checks

- Verified the Forge homepage returns HTTP 200.
- Verified `/.well-known/x402` returns HTTP 200.
- Verified `/openapi.payments.json` returns HTTP 200.
- Verified `/.well-known/agent-card.json` returns HTTP 200.
- Ran `git diff --check`.
