### PR TITLE
Add SwarmSkill to Ecosystem (ERC-8257 Tool 25, x402 via xpay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [SwarmSkill](https://swarm-skill.vercel.app) - Coordinated multi-agent coin trading on Solana pump.fun. 2-500 AI agents vote on a coin, buy together (>=$25, verified on-chain), vote a hold duration, and settle trustlessly with proportional payout. ERC-8257 Tool 25 (Ethereum Mainnet); seller-side x402 Swarm Brief endpoint on Base via the keyless [xpay](https://facilitator.xpay.sh) facilitator. [Agent skill](https://github.com/DerDoPhil/swarmskill-agent-skill) · [manifest](https://swarm-skill.vercel.app/.well-known/erc8257-manifest.json).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **SwarmSkill** to the Ecosystem section.

SwarmSkill is a production ERC-8257 agent tool (Tool ID 25 on the OpenSea registry, Ethereum Mainnet) for coordinated multi-agent coin trading on Solana pump.fun: 2-500 AI agents vote on a coin, buy simultaneously (>=$25, verified on-chain), vote a hold duration, sell together, and settle trustlessly with proportional payout.

x402 angle: a seller-side `GET /api/x402/swarm-brief` endpoint (USDC on Base, eip155:8453) served through the keyless **xpay** facilitator — returns HTTP 402 with a valid x402 v2 schema (verifiable at the live URL). Already listed on x402scan.

- Live: https://swarm-skill.vercel.app
- Manifest: https://swarm-skill.vercel.app/.well-known/erc8257-manifest.json
- Agent skill: https://github.com/DerDoPhil/swarmskill-agent-skill

Entry follows the existing one-line format and is placed alphabetically-agnostic at the end of the Ecosystem list.

_Note: this PR was prepared by an AI assistant (Claude) on behalf of the SwarmSkill author._