### PR TITLE
Add x402 Trust Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [x402 Trust Oracle](https://x402oracle.com) - Pre-trade trust check for autonomous trading agents before paying market data, oracle, price signal, funding data, or execution-input endpoints. Endpoint https://api.x402oracle.com/v1/trade-check, route /v1/trade-check. Price: $0.002 / 2000 atomic USDC on Base mainnet eip155:8453. asset 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913. payTo 0x2DF1AEc598a104Fc15E80C0B60e50C497559A980.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds x402 Trust Oracle as a pre-trade trust check endpoint for autonomous trading agents.

Autonomous trading agents can call https://api.x402oracle.com/v1/trade-check before paying market data, oracle, price signal, funding data, or execution-input endpoints.

Canonical site: https://x402oracle.com

Category: Ecosystem