### PR TITLE
Ecosystem: add QuantOracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [QuantOracle](https://quantoracle.dev) - Deterministic quant-finance API for AI agents — 63 calculators + composites, live crypto volatility/funding data, and QuantOracle Watch: 24/7 perp-position monitoring as a recurring x402 subscription ($5 / 30 days, Base + Solana) with HMAC-signed webhook alerts on funding-adjusted liquidation distance, funding flips, and vol regime. MCP-native (79 tools), CDP Bazaar discovery. [Watch writeup](https://quantoracle.dev/writing/crypto-liquidation-alerts-for-agents)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds QuantOracle to the Ecosystem section.

Deterministic quant-finance API for AI agents (63 calculators + composites, live crypto vol/funding data), plus **QuantOracle Watch** — 24/7 perp-position monitoring sold as a *recurring x402 subscription* ($5/30 days, Base + Solana): register a position once, get HMAC-signed webhook alerts on funding-adjusted liquidation distance, funding flips, and vol regime. A natural neighbour to AgentStatus in the list, and one of the first recurring-subscription (vs pay-per-call) x402 products. MCP-native (79 tools), discoverable via CDP Bazaar.

Single-line addition, format matches surrounding entries.