### PR TITLE
Add Superhighway to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Superhighway](https://superhighway.walls.sh) - Web search API for AI agents (search, news, images, scrape, research) with x402 pay-per-call: $0.002 USDC on Base, no signup. Also supports a free API key (1k calls/month). MCP server: `npx -y superhighway-mcp`.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Superhighway** to the Ecosystem section.

Superhighway is a hosted web search API for AI agents (search, news, images, scrape, research endpoints) with native x402 support: pay $0.002 USDC per call on Base with no signup required, or use a free API key (1k calls/month). It also ships an MCP server (`npx -y superhighway-mcp`) exposing 5 tools.

- Site: https://superhighway.walls.sh
- Pricing/API key: https://superhighway.walls.sh/pricing
- Guides: https://superhighway.walls.sh/guides

This fits alongside existing hosted x402 services in the Ecosystem section (Strale, CardZero, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)