### PR TITLE
Add PageDiff API

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [PageDiff API](https://pagediff-api.hahavoid0.workers.dev) - Archived web page diffing API for AI agents. Compare two Wayback Machine snapshots for a URL and receive structured added, removed, and modified text blocks for competitor pricing, policy, documentation, compliance, and product-page monitoring. $0.05 USDC per call on Base. ([llms.txt](https://pagediff-api.hahavoid0.workers.dev/llms.txt)) ([x402 metadata](https://pagediff-api.hahavoid0.workers.dev/.well-known/x402.json)) ([OpenAPI](https://pagediff-api.hahavoid0.workers.dev/openapi.json))
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds PageDiff API to the Example Apps section.

PageDiff API is an x402 paid API for archived web page diffing. It compares two Wayback Machine snapshots for a URL and returns structured added, removed, and modified text blocks.

Useful for:
- competitor pricing monitoring
- terms/privacy policy changes
- documentation drift
- compliance-page monitoring
- product-page changes

Links:
- Website: https://pagediff-api.hahavoid0.workers.dev
- llms.txt: https://pagediff-api.hahavoid0.workers.dev/llms.txt
- x402 metadata: https://pagediff-api.hahavoid0.workers.dev/.well-known/x402.json
- OpenAPI: https://pagediff-api.hahavoid0.workers.dev/openapi.json

Price:
$0.05 USDC per call on Base.