### PR TITLE
Add Agent Ready to the Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Agent Ready](https://agent-ready.dev) - AI agent-readability scanner that scores any website against the Vercel Agent Readability Spec, llmstxt.org, and agent-protocol manifests. Accepts x402 v2 pay-per-scan (USDC on Base mainnet — $0.02 / 25 pages or $0.25 / 250 pages) at `/api/x402/scan`; discoverable on the CDP Bazaar and via `/.well-known/x402`.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Agent Ready** to the **Ecosystem** section (grouped under an existing section per the contributing guidelines).

[Agent Ready](https://agent-ready.dev) is a live x402-accepting AI agent-readability scanner: it scores any website against the Vercel Agent Readability Spec, llmstxt.org, and agent-protocol manifests, and accepts x402 **v2** pay-per-scan in USDC on Base mainnet ($0.02 / 25 pages, $0.25 / 250 pages) at `/api/x402/scan`.

- Registered on x402scan: https://www.x402scan.com/server/171b24ae-08d1-448e-ac02-91209c90718f
- Discoverable on the CDP Bazaar (v2) and at `/.well-known/x402`
- Real-money settlement proven on Base mainnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)