### PR TITLE
Add Agentix — AI agent builder with per-call x402 earnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [Agentix](https://agentix.suedeai.ai) - Publish AI agents with per-call x402 payments. Creators earn on every call; buyers pay with USDC on Base.
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.


### PR DESCRIPTION
## Summary

Adds [Agentix](https://agentix.suedeai.ai) to the **Ecosystem** section.

Agentix is an AI agent builder where creators publish agents with per-call x402 micropayments. Buyers pay in USDC on Base; creators earn on every call via Coinbase CDP settlement.

Entry added:

```
- [Agentix](https://agentix.suedeai.ai) - Publish AI agents with per-call x402 payments. Creators earn on every call; buyers pay with USDC on Base.
```