### PR TITLE
Add Darrylbots x402 research resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Starter Kit – by Nader Dabit](https://github.com/dabit3/x402-starter-kit) – Simplest starter kit for building and deploying x402 APIs quickly.
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
+- [Darrylbots x402 Research](https://tryponcho.com/m/darrylbots.com) - Agent-readable paid JSON research endpoints using x402 on Base USDC. Includes stock-screen reports and Polymarket/trading-agent analysis with structured rankings, risks, provenance, and disclaimers. [Catalog](https://darrylbots.com/x402.json)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
 
 


### PR DESCRIPTION
Adds Darrylbots x402 Research to the Example Apps section.\n\nDarrylbots exposes agent-readable paid JSON research endpoints using x402 on Base USDC, including stock-screen reports and Polymarket/trading-agent analysis with structured rankings, risks, provenance, and disclaimers.\n\nLinks:\n- Merchant page: https://tryponcho.com/m/darrylbots.com\n- Catalog: https://darrylbots.com/x402.json\n- x402scan server page: https://www.x402scan.com/server/35285845-c871-4694-847b-c9b727cb474f