### PR TITLE
docs: add Suede AI ecosystem entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Suede AI](https://suedeai.ai/) - Agent-native creative commerce stack for music, video, rights lookup, and programmable IP, with 22 x402-discoverable resources settling in USDC on Base.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Suede AI / Suede Agent Studio to the relevant curated list section.

Live references checked June 18, 2026:
- Suede AI: https://suedeai.ai
- x402 discovery: https://app.suedeai.ai/.well-known/x402
- x402 JSON: https://app.suedeai.ai/.well-known/x402.json
- Agent card: https://app.suedeai.ai/.well-known/agent-card.json
- Agent Studio: https://agents.suedeai.ai

Suede exposes x402-payable creative IP endpoints for music, video, musician tools, rights lookup, and audio analysis, settling in USDC on Base. Agent Studio publishes agent catalog entries, x402 manifests, agent cards, and A2A surfaces.
