### PR TITLE
Add Loadbay to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Loadbay](https://loadbay.xyz) - Discovery catalog of 370+ open-source AI-agent harnesses (MCP servers, SDKs, adapters) across 11 domains. Agents connect over MCP to search and list; authors earn USDC tips via x402 on Base and Solana. Listed in the official MCP registry as `xyz.loadbay/loadbay`.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
### What
Adds **Loadbay** ([loadbay.xyz](https://loadbay.xyz)) to the **Ecosystem** section, alongside other agent-commerce discovery platforms (Pyrimid, Onyx Bazaar, x402 Ecosystem Directory).

### Why it fits
Loadbay is an agent-native discovery catalog of **370+ open-source AI-agent harnesses** (MCP servers, SDKs, adapters) across 11 domains. Agents connect over MCP to `search_harnesses` / `list_domains` / `get_harness`, and harness authors earn **USDC tips via x402** on Base and Solana.

- Live MCP endpoint: `https://loadbay.xyz/api/mcp`
- Listed in the official MCP registry as `xyz.loadbay/loadbay`

Grouped under the existing **Ecosystem** section per the contribution guidelines; single focused change.