### PR TITLE
Add Crest x402 Data (agent profiling + crypto market data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) - Free public leaderboard of every paid x402 service indexed via the Coinbase CDP discovery API. Refreshed every 15 min, four views (top by volume / unique payers / recently active / cheapest), JSON variant at `/bazaar.json`. Complementary CDP-only slice next to x402Scan's multi-source view.
+- [Crest Verify](https://verify.crestsystems.ai) - x402 verification tools for agent commerce, with signed trust receipts and [Supership](https://supership.crestsystems.ai) trust oracle integration.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 
 ### Example Apps
+- [Crest x402 Data](https://data.crestsystems.ai) - x402 agent profiling and crypto market data. Wallet intelligence (whale score, behavior cluster, x402 spend graph, risk) for profiling x402 buyers, plus prices, gas, DeFi, derivatives, NFTs, and DEX pairs. Pay-per-call USDC on Base via the Coinbase CDP facilitator, no API keys. ([Agent Card](https://data.crestsystems.ai/.well-known/agent.json) | [llms.txt](https://data.crestsystems.ai/llms.txt))
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.


### PR DESCRIPTION
Adds **Crest x402 Data** to Example Apps.

Live x402 service on Base, settled via the Coinbase CDP facilitator (indexed in the CDP Bazaar). The distinct angle is **x402 agent profiling**: a wallet-intelligence endpoint that profiles x402 buyers (whale score, behavior cluster, x402 spend graph, risk), alongside a standard crypto market-data suite.

- Pricing: $0.002-$0.90 USDC on Base, no API keys
- Agent card: https://data.crestsystems.ai/.well-known/agent.json
- llms.txt: https://data.crestsystems.ai/llms.txt

Endpoints return valid x402 402 responses and the domain is verified on 402index.io.