### PR TITLE
Add Clearance Agent Income and BOT-COMM

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Clearance Agent Income / BOT-COMM](https://clearance.nauti-labs.com/agent-income/agents.json) - Paid x402 readiness audits, payment-flow reviews, integration blueprints, and bot-to-bot commerce services on Base USDC. Live HTTP 402 endpoints publish machine-readable payment requirements and require payment before fulfillment. ([BOT-COMM manifest](https://clearance.nauti-labs.com/bot-comm/agents.json), [repo](https://github.com/Nauti-Labs/clearance))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Nauti-Labs Clearance Agent Income / BOT-COMM to the x402 ecosystem list.\n\nThe services expose live HTTP 402/x402-compatible endpoints for paid AI payment-readiness audits, payment-flow reviews, integration blueprints, and bot-to-bot commerce services on Base USDC.