### PR TITLE
Add AnyAPI to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AnyAPI](https://getanyapi.com) - Unified marketplace for scraping and data APIs. Hundreds of third-party data APIs behind one key, schemas normalized across providers with automatic failover. Agents pay inline per call with no account via x402 (Base mainnet, USDC) across 218 endpoints under `POST /v1/run/{sku}`. ([OpenAPI](https://api.getanyapi.com/openapi.json) | [Docs](https://getanyapi.com/docs))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **AnyAPI** to the Ecosystem section.

AnyAPI ([getanyapi.com](https://getanyapi.com)) is a unified marketplace for scraping and data APIs: hundreds of third-party data APIs behind one key, with schemas normalized across providers and automatic failover. AI agents pay inline per call with no account via x402 (Base mainnet, USDC) across 218 endpoints under `POST /v1/run/{sku}`.

- OpenAPI spec: https://api.getanyapi.com/openapi.json (returns valid HTTP 402 `accepts[]` payloads)
- Docs: https://getanyapi.com/docs
- Already indexed by x402scan and the Coinbase CDP x402 Bazaar.

Single-line addition to the `### Ecosystem` section, formatted to match existing entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)