### PR TITLE
Add Clawy AI Gateway - pay-per-call x402 inference on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Example Apps
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
+- [Clawy AI Gateway](https://clawy.uk) - Pay-per-call x402 v2 inference on Base. OpenAI gpt-5.5, Anthropic claude-opus-4-8, and a cost-optimized auto tier at $0.04-$0.15 USDC per call. x402scan-listed, auto-indexed on agentic.market and x402.org/ecosystem, full Bazaar extension discovery. Live at https://clawy.uk.
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)


### PR DESCRIPTION
Adds **Clawy** (https://clawy.uk) - a production x402 v2 AI inference gateway serving OpenAI gpt-5.5, Anthropic claude-opus-4-8, and a cost-optimized auto tier at $0.04-$0.15 USDC per call. Settles on Base mainnet via the Coinbase CDP facilitator.

- Three OpenAI-compatible chat endpoints, all gated by HTTP 402
- x402scan-listed; auto-indexed on agentic.market and x402.org/ecosystem
- Machine-readable discovery files: /openapi.json, /llms.txt, /.well-known/x402.json, /.well-known/agent-services.json, /health
- Bazaar extension discovery (input/output schemas) so agents can self-integrate
- Has received real on-chain settlements from external buyers

Service is live (verified: /health returns 200, v1.2.0). One-line addition under Example Apps.
