### PR TITLE
Add Zero to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 
 - [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
+- [Zero](https://github.com/officialzeroxyz/zero-plugins) - x402/MPP implementation: a CLI, MCP connector, and Claude Code plugin that lets your AI discover and pay for real services per use. ([Site](https://zero.xyz))
 ### Standards and EIPs
 - [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.
 - [HTTP 402 Payment Required (IANA Registry)](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml): canonical HTTP status-code registry entry for 402.


### PR DESCRIPTION
## Summary

Adds **Zero** to Open Source & SDKs. Zero is an x402/MPP implementation - a CLI (`@zeroxyz/cli`), an MCP connector (`mcp.zero.xyz`), and a Claude Code plugin - that lets your AI discover and pay for real services per use. Free to start ($5 of credit; most calls cost pennies).

Disclosure: I work on Zero's go-to-market - happy to tweak the wording, move the section, or close this if it is not a fit.