### PR TITLE
Add AgentFlow (wash/sybil screening + Real-Agent Index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AgentFlow](https://agentflow.watch) - Wash/sybil screening + the Real-Agent Index for Base agent wallets. Screen any wallet ("real autonomous agent or fake-volume sybil?") via an x402-paid API ($0.01/call, USDC, no signup) plus a free MCP server (Streamable HTTP, 5 read tools). Publishes the honest real-vs-fake agent benchmark on Base.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **AgentFlow** to the Ecosystem section.

AgentFlow screens Base wallets for wash/sybil behavior — "is this a real autonomous agent or a fake-volume sybil?" — as an x402-paid API ($0.01/call in USDC, no signup) plus a free MCP server (Streamable HTTP, 5 read tools: `screen_wallet`, `counterparty_risk`, `real_agent_index`, `agent_pulse`, `index_stats`). It also publishes the Real-Agent Index: the share of "AI agent" USDC flow on Base that is wash/self-dealing vs. genuine one-way payments.

- Site: https://agentflow.watch
- MCP: https://agentflow.watch/mcp
- Benchmark: https://agentflow.watch/index.json

Live and indexing Base every 2 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
