### PR TITLE
Add Biotech Catalyst Sentinel (FDA PDUFA dates API) to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
+- [Biotech Catalyst Sentinel](https://biotechcatalystsentinel.com) - Upcoming FDA PDUFA decision dates for US-listed biotechs, extracted from primary SEC 8-K/6-K filings and independently accuracy-backtested (median 1-day error). One paid endpoint, $0.02/call USDC on Base or Solana, with a free accuracy proof at `/v1/accuracy`. Live on CDP Bazaar, 402index, and x402scan.
+
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
-- [Biotech Catalyst Sentinel](https://biotechcatalystsentinel.com) - Upcoming FDA PDUFA decision dates for US-listed biotechs, extracted from primary SEC 8-K/6-K filings and independently accuracy-backtested (median 1-day error). One paid endpoint, $0.02/call USDC on Base or Solana, with a free accuracy proof at `/v1/accuracy`. Live on CDP Bazaar, 402index, and x402scan.
+- [Biotech Catalyst Sentinel](https://biotechcatalystsentinel.com) - Upcoming FDA PDUFA decision dates for US-listed biotechs, extracted from primary SEC 8-K/6-K filings and backtested against actual FDA decisions (median 1-day error, independently verifiable). One paid endpoint, $0.02/call USDC on Base or Solana, with a free accuracy proof at `/v1/accuracy`. Live on CDP Bazaar, 402index, and x402scan.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Biotech Catalyst Sentinel** to the Ecosystem section (alongside other agent-facing data APIs like Strale).

A machine-first x402 API serving upcoming **FDA PDUFA decision dates** for US-listed biotechs, extracted from primary SEC 8-K/6-K filings and independently accuracy-backtested (median 1-day error). One paid endpoint, **$0.02/call USDC on Base or Solana**, with a **free accuracy proof** at `/v1/accuracy` anyone can verify before paying.

- API: `GET https://api.biotechcatalystsentinel.com/v1/catalysts/upcoming`
- Discovery: https://api.biotechcatalystsentinel.com/.well-known/x402
- Already live on CDP Bazaar, 402index.io, and x402scan.

Single-line addition; all links verified live.