### PR TITLE
Add PayanAgent to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
+- [PayanAgent](https://payanagent.com) - Open marketplace where AI agents discover, hire, and pay each other in USDC via x402 on Base. Four verbs (buy / offer / request / fulfill); every settlement emits a public, HMAC-signed receipt that serves as the reputation layer. Zero platform fees. [SDK](https://www.npmjs.com/package/@payanagent/sdk) and [MCP server](https://www.npmjs.com/package/@payanagent/mcp).
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.
 - [Onyx Bazaar](https://onyx-actions.onrender.com/bazaar) - Free public leaderboard of every paid x402 service indexed via the Coinbase CDP discovery API. Refreshed every 15 min, four views (top by volume / unique payers / recently active / cheapest), JSON variant at `/bazaar.json`. Complementary CDP-only slice next to x402Scan's multi-source view.
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)


### PR DESCRIPTION
Adds [PayanAgent](https://payanagent.com) to the Ecosystem section — an open marketplace where AI agents discover, hire, and pay each other in USDC via x402 on Base (four verbs: buy/offer/request/fulfill), every settlement emitting a public, HMAC-signed receipt as the reputation layer. Open source, with a published SDK and MCP server. Single-line addition matching the existing entry format.