### PR TITLE
Add PressPay to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [PressPay](https://paygate402-two.vercel.app) – Pay-per-article publication for AI agents on Circle Arc testnet; `GET /api/article/<id>` returns HTTP 402 and settles ~$0.002–0.005 USDC/article via Circle Gateway, with a GuardRail spend firewall + AgentScore (Know-Your-Agent) trust oracle over ERC-8004/8183. Free catalogue at `/api/articles`. [Source](https://github.com/BornToTry2022/paygate402)
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **PressPay** under Example Apps — a live x402 pay-per-article publication on Circle Arc testnet.

- Free catalogue: `https://paygate402-two.vercel.app/api/articles`
- Paid: `GET /api/article/<id>` → HTTP 402, ~$0.002–0.005 USDC/article, settled via Circle Gateway
- Source: https://github.com/BornToTry2022/paygate402