### PR TITLE
Add Casa — E2E-encrypted, permanent file storage for AI agents (x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Casa](https://casa-agents.fly.dev) – Dropbox for AI agents: end-to-end encrypted, permanent file storage paid per-call ($0.01 USDC on Base) via x402. Upload any file, get back a permanent gateway URL. Stored forever on Arweave by default (Swarm for large files); the client encrypts before upload so Casa is zero-knowledge (only your wallet can decrypt). Reads are free, no API keys, no signup. Machine-readable discovery at [/llms.txt](https://casa-agents.fly.dev/llms.txt), [/openapi.json](https://casa-agents.fly.dev/openapi.json) and [/.well-known/x402.json](https://casa-agents.fly.dev/.well-known/x402.json).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **Casa** to the Example Apps section, alongside the other storage examples (Pinata pay-to-pin).

Casa is a live, production x402 service: an agent uploads any file, pays $0.01 USDC on Base via x402, and gets back a permanent gateway URL. Stored forever on Arweave by default (pay-once endowment; Swarm for large files). The client encrypts before upload, so Casa is zero-knowledge — only the paying wallet can decrypt. Reads are free, no API keys, no signup.

Machine-readable discovery: /llms.txt, /openapi.json, /.well-known/x402.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)