### PR TITLE
Add Proxygate to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Proxygate](https://proxygate.ai) - Curated marketplace of real-world data APIs for AI agents. One prepaid USDC balance on Solana topped up over x402; connect via MCP, SDK, CLI, or REST API and call any listing per request, with seller keys injected server-side and a signed receipt per call.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Proxygate to the Ecosystem section. Curated marketplace of real-world data APIs for AI agents: one prepaid USDC balance on Solana topped up over x402, connect via MCP/SDK/CLI/REST and call any listing per request with seller keys injected server-side and a signed receipt per call.