### PR TITLE
Add Strumly — first music oracle on x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- **[Strumly](https://strumly.suedeai.ai/agents)** — The only music oracle on x402. Canonical chord knowledge, song analysis, chord-progression transcription, and personalized practice plans for AI agents. No other music API exists in the x402 ecosystem. $0.99–$4.99 USDC/call on Base · $9.99 Stripe 24h day pass · 5 free calls/IP/day. Full discovery: [/.well-known/x402](https://strumly.suedeai.ai/.well-known/x402) · [OpenAPI](https://strumly.suedeai.ai/openapi.json) · [llms.txt](https://strumly.suedeai.ai/llms.txt). By [Suede Labs AI](https://suedeai.ai).
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.


### PR DESCRIPTION
## What this adds

**[Strumly](https://strumly.suedeai.ai/agents)** — the first and only music oracle in the x402 ecosystem.

No music API exists in this list. Strumly fills that gap.

### What it does

Verified music data for AI agents: canonical chord knowledge, song analysis, chord-progression transcription, personalized practice plans. Answers grounded in verified theory and attested song data.

### x402 details

- Full x402 v1 via Coinbase CDP facilitator (USDC on Base)
- `/.well-known/x402`: https://strumly.suedeai.ai/.well-known/x402
- OpenAPI: https://strumly.suedeai.ai/openapi.json
- llms.txt: https://strumly.suedeai.ai/llms.txt
- 5 free calls/IP/day · $0.99–$4.99/call · $9.99 24h day pass (Stripe)

### Quick test

```bash
curl -X POST https://strumly.suedeai.ai/api/v1/ask \
  -H 'Content-Type: application/json' \
  -d '{"question":"What chords are in a 12-bar blues in E?"}'
# → HTTP 402 with USDC payment metadata
```

By [Suede Labs AI](https://suedeai.ai).