### PR TITLE
Add J-sey: pay-per-call data API on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
+- [J-sey](https://johncross-data-api.johncrossugwuegede.workers.dev) - Pay-per-call data API on Base: wallet lookups, web scraping, and crypto price data. USDC at $0.002/call via Coinbase CDP facilitator.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))


### PR DESCRIPTION
Adding J-sey - a live x402 service offering wallet lookups, web scraping, and crypto price data on Base. Bazaar-listed, USDC payments at $0.002/call via Coinbase CDP facilitator.