### PR TITLE
Add Verity (VerityLayer) to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Verity (VerityLayer)](https://verity-bzw7.onrender.com) - Fail-closed verify-before-you-act trust gate for AI agents: returns a verdict (supported/unsupported/uncertain), a calibrated 0–1 confidence, and evidence — abstains rather than fabricate. Keyless, pay-per-call via x402 in USDC on Base. Tiers: /verify/quick $0.02 · /verify $0.25 (grounded, live citations) · /verify/pro $0.35. Also ships an [MCP server](https://veritylayer.dev) (`io.github.meloliva14/verity-mcp`).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Verity (VerityLayer)** to the Ecosystem section. Verity is a fail-closed "verify-before-you-act" trust gate for AI agents: it returns a verdict (supported/unsupported/uncertain), a calibrated 0–1 confidence, and evidence, abstaining rather than fabricate. It's keyless and pay-per-call via x402 in USDC on Base, with three tiers (/verify/quick $0.02, /verify $0.25 grounded with live citations, /verify/pro $0.35) and an MCP server (io.github.meloliva14/verity-mcp). The live x402 manifest is published at https://verity-bzw7.onrender.com/.well-known/x402.json.