### PR TITLE
Add Tantra Authority — 49 x402 offers (USDC on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Tantra Authority / The Naked Press](https://api.tantra-authority.com) - Live production x402 storefront exposing 49 AOP offers (courses, eBooks, meditations, readings), each pay-per-request in USDC on Base. [Offer discovery](https://index.adagencyforagents.com/v0/offers).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **Tantra Authority / The Naked Press** to the Example Apps section. It's a live production x402 storefront exposing 49 AOP offers (courses, eBooks, meditations, readings), each purchasable pay-per-request in USDC on Base. Public offer discovery at https://index.adagencyforagents.com/v0/offers lets agents enumerate and buy.