### PR TITLE
Add Yield.xyz AgentKit (DeFi yield MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Yield.xyz AgentKit](https://mcp.yield.xyz/mcp) - DeFi yield discovery & execution MCP server across 80+ networks (staking, lending, vaults, RWAs). Free discovery tier; paid tools (wallet balances, unsigned tx building) at $0.001 USDC per call on Base via x402, no signup. ([discovery manifest](https://mcp.yield.xyz/.well-known/x402))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Yield.xyz AgentKit** — an MCP server exposing DeFi yield discovery & execution across 80+ networks (staking, lending, vaults, RWAs).

- Endpoint: https://mcp.yield.xyz/mcp
- x402 discovery manifest: https://mcp.yield.xyz/.well-known/x402
- Base mainnet (eip155:8453), USDC, $0.001/call. Free discovery tier; paid tools for wallet balances and unsigned transaction building. No signup — agents pay via x402.

Live and indexed in the CDP Bazaar.