### PR TITLE
Add Kronos Signals (x402 crypto forecast + derivatives API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Kronos Signals](https://kronossignals.com) - Pay-per-call crypto forecasts & derivatives intelligence for agents on Base: $0.01 Kronos-base BTC price forecasts (40-path Monte-Carlo up-probability, ranges, quantiles) and $0.02 BTC/ETH/SOL funding/OI signals & regime alerts, with a public auto-scored track record ([/api/stats](https://kronossignals.com/api/stats)) and free samples.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **Kronos Signals** to the Example Apps section.

[kronossignals.com](https://kronossignals.com) is a live, x402-paywalled API for AI agents on Base mainnet: $0.01 Kronos-base BTC price forecasts (40-path Monte-Carlo) and $0.02 BTC/ETH/SOL funding/OI derivatives signals and regime alerts. Settlement is USDC via the Coinbase CDP facilitator.

Every forecast is auto-scored against realized outcomes, so the track record is publicly verifiable at [/api/stats](https://kronossignals.com/api/stats). Machine discovery via `/.well-known/x402` and `/api/openapi.json`; free sample endpoints at `/api/v1/sample/{btc,eth,sol}`. Single-line addition, alphabetized within its list neighbors.