### PR TITLE
Add x402stats — independent x402 adoption statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
+- [x402stats](https://x402stats.io) - Independent x402 adoption statistics with wash-filtered "organic" metrics: daily volume, sellers, buyers and facilitator market share since May 2025 — published methodology, free CSV/JSON (CC BY 4.0), llms-full.txt for agents.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.


### PR DESCRIPTION
Adds [x402stats](https://x402stats.io) to the Ecosystem section.

x402stats publishes independent, methodology-filtered x402 adoption statistics: daily volume, active sellers, unique buyers, and facilitator market share across 10+ facilitators and chains, with full history since 2025-05-09. Its distinguishing feature is the wash-filtered "organic" metric set (versioned methodology at https://x402stats.io/methodology — excludes wash trading, dust loops, and facilitator settlement wallets) published alongside the raw numbers. Data is free under CC BY 4.0 (CSV/JSON), with llms.txt / llms-full.txt for agent consumption. Updated continuously; a weekly automated snapshot grows an append-only raw-vs-organic record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)