### PR TITLE
Add DeadDrop to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [DeadDrop](https://deaddrop.jerrywrongalot.workers.dev) - Zero-knowledge one-time-secret relay: AES-256-GCM in-browser, the key rides the URL fragment (server stores ciphertext only), atomic single read via a Durable Object, then the secret is gone. $0.01 USDC per secret over x402 on Base (CDP facilitator); reading is free so recipients need no wallet. Includes an MCP server so agents can drop and reveal secrets natively.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds DeadDrop - a zero-knowledge one-time-secret relay paid per call over x402.

- Live service: https://deaddrop.jerrywrongalot.workers.dev (in-browser demo on the landing, no payment needed to try the crypto flow)
- x402 exact scheme, $0.01 USDC on Base via the CDP facilitator; reading is free so recipients need no wallet
- AES-256-GCM client-side, key in the URL fragment (server stores ciphertext only), atomic one-time read via a Durable Object
- Includes an MCP server so agents can create/reveal secrets natively

One line under Example Apps, matching the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)