### PR TITLE
Add true402 to the Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [true402](https://true402.dev) - Machine-native x402 marketplace of pay-per-call stalls on Base (USDC), no account or API key. Token-safety stalls run a real on-chain buy/sell honeypot simulation (state-override eth_call) proving sellability; also DeFi signals, web/SEO audits, and LLM inference.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **true402** to the Ecosystem. A machine-native [x402](https://x402.org) marketplace of pay-per-call stalls on Base (USDC) — no account or API key, the wallet is the identity. The token-safety stalls run a real on-chain buy/sell honeypot simulation (state-override `eth_call`) that proves sellability. https://true402.dev