### PR TITLE
Add NanoVPN (pay-per-request geo egress for agents) to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [NanoVPN](https://nanovpn-web.vercel.app) - Pay-per-request geo-located web egress for humans and AI agents. Agents pay USDC per request via x402 to fetch a URL through a node in a chosen city (returns HTTP status, bytes, and egress IP); verify→fetch→settle so failed fetches aren't charged. Circle Gateway nanopayments on Arc testnet; 17 nodes across 6 continents. [Agent docs](https://nanovpn-web.vercel.app/use-with-agent)
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds **NanoVPN** to *Example Apps*.

A live x402 app: pay-per-request, geo-located web egress for humans and AI agents. Agents pay USDC per request via x402 to fetch a URL through a node in a chosen city (returns HTTP status, bytes, and the node's egress IP as geo proof); verify → fetch → settle so a failed fetch is never charged. Settled as Circle Gateway nanopayments on Arc testnet, across 17 nodes / 6 continents.

- Site: https://nanovpn-web.vercel.app
- Agent docs: https://nanovpn-web.vercel.app/use-with-agent
- Node/price discovery: https://nanovpn-web.vercel.app/api/nodes

Grouped under the existing Example Apps section with a concise description, per CONTRIBUTING.