### PR TITLE
Add deposit.now to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [deposit.now](https://deposit.now) - Public x402 API for AI agents to autonomously deposit funds. Pay-per-call (0.01 USDC, exact scheme) on Base with Bazaar discovery declared on the route, llms.txt for LLM crawlers, and JS/Python client examples in the [docs](https://deposit.now/docs).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds deposit.now — a public x402 API for AI agents to autonomously deposit funds.

- Pay-per-call: 0.01 USDC, exact scheme, x402 v2
- Bazaar discovery extension declared on the route (input/output schemas in the 402 payload)
- llms.txt + schema.org WebAPI JSON-LD for agent/LLM discovery
- JS (@x402/fetch) and Python (x402[httpx]) client examples at https://deposit.now/docs
- Verify: curl -i -X POST https://deposit.now/api/deposit returns a spec-compliant 402 with Payment-Required header

🤖 Generated with [Claude Code](https://claude.com/claude-code)