### PR TITLE
Add DDG Agent-Payable Services to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [DDG Agent-Payable Services](https://agents.daedalusdevelopmentgroup.com) - Pay-per-call gateway for AI agents: 90+ x402 tools (utilities, blockchain RPC, market data, security audits) plus an OpenAI-compatible LLM gateway. USDC on Base, free-trial calls per agent. MCP: `io.github.daedalusdevelopmentgroup/ddg-agent-services-mcp` ([registry](https://registry.modelcontextprotocol.io/)) · [PyPI](https://pypi.org/project/ddg-agent-services-mcp/).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds DDG Agent-Payable Services to the Ecosystem list.

**DDG Agent-Payable Services** — a pay-per-call gateway for AI agents at https://agents.daedalusdevelopmentgroup.com : 90+ x402 tools (utilities, blockchain RPC, market data, security audits) plus an OpenAI-compatible LLM gateway. Settles in USDC on Base; most routes grant free-trial calls per agent.

- Live x402 manifest: https://agents.daedalusdevelopmentgroup.com/.well-known/x402
- MCP server (Official Registry): `io.github.daedalusdevelopmentgroup/ddg-agent-services-mcp`
- PyPI: https://pypi.org/project/ddg-agent-services-mcp/

One entry added alphabetically-adjacent in the Ecosystem section; follows the existing format.