### PR TITLE
Add JMT x402 Agent Tools — 25 Base mainnet endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 
 ### Example Apps
+- [JMT x402 Real-Money Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 pay-per-call API endpoints for AI agents on Base mainnet. AI-powered research, company intelligence, SEC filing analysis, news briefings, social sentiment, crypto research, competitor analysis, regulatory monitoring, and utilities. Dexter facilitator (0% fee, gas-sponsored). Also as [MCP server](https://github.com/jmthomasofficial/x402-mcp-server). ([Discovery](https://jmt-x402-proxy.jmthomasofficial.workers.dev/.well-known/x402))
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.


### PR DESCRIPTION
25 pay-per-call API endpoints for AI agents on Base mainnet using Dexter facilitator (0% fee, gas-sponsored). AI-powered research, company intelligence, SEC filing analysis, news briefings, social sentiment, crypto research, competitor analysis, regulatory monitoring, macro dashboards, market pulse, domain trust scores, and utility endpoints. Price range $0.001-$0.15/call. Also available as MCP server: https://github.com/jmthomasofficial/x402-mcp-server. Discovery: /.well-known/x402 (version 1, resources array) + OpenAPI with x-payment-info on all operations.