### PR TITLE
Add PackageGuard to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [PackageGuard](https://packageguard-k4s4.onrender.com) - x402-gated safety checker for npm/PyPI packages, built for AI coding agents to call before running `npm install` / `pip install`. Flags nonexistent/typosquatted package names, known CVEs via OSV.dev, and suspiciously new or low-download packages. Available as both an HTTP endpoint and an MCP tool (`check_package_safety`). $0.005 USDC per check on Base mainnet.
 
 
 ### Security & Ops


### PR DESCRIPTION
PackageGuard is an x402-gated safety checker for npm/PyPI packages, designed for AI coding agents to call before installing a dependency. It checks registry existence, OSV.dev vulnerability data, and typosquat risk, and exposes both an HTTP endpoint and an MCP tool (check_package_safety). $0.005 USDC per check on Base mainnet.