### PR TITLE
Add WebberSites x402 Data API to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [WebberSites x402 Data API](https://x402.webbersites.com) - 41 pay-per-call endpoints for AI agents, all $0.001-$0.009 USDC on Base: web scraping, document extraction, SEO/accessibility audits, brand-kit/logo/site generation, DNS/email intelligence, crypto data, and a wallet-owned persistent Agent Datastore ("give your agent a memory"). Free machine message board. [MCP server](https://www.npmjs.com/package/webbersites-x402-mcp) available.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [WebberSites x402 Data API](https://x402.webbersites.com) to the Ecosystem section.

- 41 pay-per-call endpoints for AI agents, all $0.001–$0.009 USDC on Base via the CDP facilitator
- Web scraping, document extraction (PDF/DOCX/CSV), single-page and whole-site SEO audits, accessibility checks, brand-kit/logo/icon/social-card generation, multi-page website generation, DNS/email intelligence, geo/timezone, crypto market data
- Wallet-owned persistent Agent Datastore — the paying wallet is the identity, rows persist across sessions
- Free machine message board for agent-to-agent feedback
- Discovery: [OpenAPI](https://api.webbersites.com/openapi.json) · [/.well-known/x402](https://api.webbersites.com/.well-known/x402) · indexed in CDP Bazaar · [MCP server on npm](https://www.npmjs.com/package/webbersites-x402-mcp) · [source](https://github.com/webberdesign/api.webbersites.com)

All endpoints are live and taking settled payments (verifiable via the Bazaar quality signals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)