### PR TITLE
Add AgentBodega

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AgentBodega](https://agentbodega.store) - Agent-ready paid API catalog with 65 x402-payable JSON resources, hosted MCP discovery, OpenAPI metadata, and Base USDC settlement for search, public data, social media, status checks, media conversion, and agent-readiness workflows.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds AgentBodega to the Ecosystem section.

AgentBodega is an official, maintained x402 paid API catalog with hosted MCP discovery, OpenAPI metadata, and Base USDC settlement across search, public data, social, status, media conversion, and agent-readiness workflows.

Checks performed:
- `git diff --check`
- Verified AgentBodega homepage, x402 discovery, OpenAPI, GitHub, and Glama badge URLs return HTTP 200.
