### PR TITLE
Add AgentUtility to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [agentutility](https://x402.agentutility.ai/) - Pay-per-call API catalog for AI agents: hundreds of x402 endpoints (PDF/document conversion, web scraping, transcription, image & video generation, on-chain & finance data, dev tools) payable in USDC on Base and Solana. No signup or API key; ERC-8004 identity (agentId 47167); machine-readable catalog at `/` and OpenAPI at `/openapi.json`.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds one entry for AgentUtility (https://x402.agentutility.ai), a catalog of x402 v2 endpoints with Base + Solana payment support, an MCP package catalog, and per-endpoint OpenAPI specs.