### PR TITLE
Add QueryLines to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [QueryLines](https://querylines.com) - Surplus lines market data, per query. Pay-per-query U.S. excess & surplus (E&S) insurance market statistics from state stamping office publications, with x402 USDC payments on Base and paid MCP tools. ([OpenAPI](https://api.querylines.com/openapi.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [QueryLines](https://querylines.com) to the Ecosystem section.

Surplus lines market data, per query: a pay-per-query API for U.S. excess & surplus (E&S) insurance market statistics from state stamping office publications. Live x402 v2 seller on Base mainnet via the CDP facilitator with Bazaar discovery on every 402; paid MCP tools at https://api.querylines.com/mcp (official MCP Registry: com.querylines/mcp); OpenAPI at https://api.querylines.com/openapi.json. $0.10 single-state query, $0.50 cross-state compare, free discovery endpoints, no API keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)