### PR TITLE
Add Dokimo to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Dokimo](https://dokimo.augaster.com) - Verifiable ASC-606 revenue subledger for x402/agentic payments: audit-ready books from agent payments with a cryptographic proof an auditor replays to the on-chain settlement. Includes a live x402-paid Verify API.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Dokimo — a verifiable ASC-606 revenue subledger for x402/agentic payments: audit-ready books from agent payments with a cryptographic proof an auditor can replay to the on-chain settlement (non-custodial). Live at dokimo.augaster.com with an x402-paid Verify API. Thanks for maintaining this list!