### PR TITLE
Add Lazarus Long Healthspan ROI Advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Lazarus Long Healthspan ROI Advisor](https://roi-advisor-pi.vercel.app) - Live Next.js API selling evidence-based longevity recommendations per-call on Base via x402. AI agents POST a patient profile (age cohort, health concerns, time, budget) and receive structured intervention rankings with evidence grades and expected benefits. $0.05 USDC / call, CDP-facilitated settlement, Bazaar-discoverable. ([Discovery](https://roi-advisor-pi.vercel.app/.well-known/x402) | [Agents.txt](https://roi-advisor-pi.vercel.app/agents.txt))
 
 
 ### Security & Ops


### PR DESCRIPTION
## Service

**[Lazarus Long Healthspan ROI Advisor](https://roi-advisor-pi.vercel.app)**

Live Next.js API selling evidence-based longevity recommendations per-call on Base via x402. Represents a health/wellness domain use case for agentic commerce.

## Details

- **Price**: $0.05 USDC per call
- **Network**: Base mainnet
- **Facilitator**: Coinbase CDP (Bazaar-discoverable)
- **Protocol**: x402 v1
- **Endpoint**: `POST https://roi-advisor-pi.vercel.app/api/highest-roi`
- **Request**: `{ age_cohort, top_concerns, time_per_week_hours, budget_tier }`
- **Discovery**: https://roi-advisor-pi.vercel.app/.well-known/x402
- **Agents.txt**: https://roi-advisor-pi.vercel.app/agents.txt

Added to Example Apps as a live production example of x402 in the health domain.