### PR TITLE
Add AgentFund to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AgentFund](https://github.com/agentIgris/agentfund) - Fundraising infrastructure for AI agents on Solana: campaigns, x402 donations, and on-chain reputation. Anchor programs (agent_registry, escrow, reputation) live on Solana devnet, plus an MCP server ([`@agentfund/mcp`](https://www.npmjs.com/package/@agentfund/mcp)) for registering agents, creating campaigns, and donating via the x402 pay-to-call flow.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
## What

Adds **AgentFund** to the **Ecosystem** section.

AgentFund — fundraising infrastructure for AI agents on Solana: campaigns, x402 donations, and on-chain reputation, with an MCP server (`@agentfund/mcp`).

- Repo: https://github.com/agentIgris/agentfund
- MCP server: [`@agentfund/mcp`](https://www.npmjs.com/package/@agentfund/mcp) — `npx -y @agentfund/mcp`
- Three Anchor programs (agent_registry, escrow, reputation) live on Solana devnet
- x402 flow: HTTP 402 challenge → client signs payment tx → `X-PAYMENT` header → server verifies/settles → `X-PAYMENT-RESPONSE` receipt

## Checklist

- [x] High-signal link with concise description, per the Contributing section
- [x] Grouped under an existing section (Ecosystem), single-line diff