### PR TITLE
Add HashProof, Lotero and CompraBTC to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server. Triggers USDC charity donations on every HTTP event via x402. Express/Next.js middleware, CLI, Vercel-ready. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 
 ### Example Apps
+- [HashProof](https://hashproof.dev) - Verifiable credentials API: issue diplomas and certificates for $0.10 via x402 (USDC on Base or Celo), registered on-chain and pinned to IPFS. Agent-first: [skill](https://hashproof.dev/skill.md), MCP server and free inline template preview. [Code](https://github.com/csacanam/hashproof).
+- [Lotero](https://lotero.xyz) - Provably fair on-chain slot machine for agents: 1.1 USDC spins via x402 on Base, Chainlink VRF randomness, gasless claims. [Code](https://github.com/csacanam/lotero-core).
+- [CompraBTC](https://comprabtc.vercel.app) - Non-custodial Bitcoin DCA agent on Celo whose keeper pays its own execution API via x402; the execution endpoint is permissionless — any x402 client can pay to trigger a due purchase. [Code](https://github.com/csacanam/comprabtc).
 - [QuickNode Video Paywall Demo](https://www.quicknode.com/sample-app-library/coinbase-x402)
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.


### PR DESCRIPTION
Three live x402 apps in production:

- **HashProof** (hashproof.dev) — verifiable credentials for $0.10 via x402, USDC on Base or Celo, on-chain + IPFS.
- **Lotero** (lotero.xyz) — provably fair slot machine, 1.1 USDC spins via x402 on Base with Chainlink VRF.
- **CompraBTC** (comprabtc.vercel.app) — non-custodial Bitcoin DCA on Celo with a permissionless x402-payable execution endpoint.

All three also ship MCP servers (official registry) and agent skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)