### PR TITLE
Add RelayShield to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [RelayShield](https://relayshield.net) - Threat intelligence and identity-risk APIs for AI agents: breach exposure, infostealer log detection, malicious MCP server checks, prompt-injection breach detection, ransomware victim lookup, and more. 24 endpoints, x402 payment support on Base and Solana via the Coinbase CDP facilitator.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds RelayShield, a threat intelligence and identity-risk API, to the Ecosystem section. 24 endpoints are x402-payable on Base and Solana via the Coinbase CDP facilitator, including agent-specific checks (malicious MCP server detection, prompt-injection breach detection) relevant to this list's audience.