### PR TITLE
Add Countersign — spend governance for paying agents (Security & Ops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 FAQ – Security](https://docs.cdp.coinbase.com/x402/support/faq#security)
 - [Compliance-Aware Agentic Payments on Stablecoin Rails](https://arxiv.org/abs/2605.00071) - Research paper on policy and compliance guardrails for x402-style stablecoin payment authorization.
+- [Countersign](https://countersign.network/docs/) - Neutral spend-governance layer for paying agents: one declarative policy, a pre-flight guard on every x402/AP2 payment, a sub-second cross-vendor kill switch, and an append-only signed audit ledger. Apache-2.0 open core.
 
 ### Benchmarks & Analysis
 - [Dev.to – x402 vs Traditional Payments (Micropayments)](https://dev.to/pathak_prakarsh/x402-finally-payments-built-for-the-internet-not-bolted-onto-it-1058)


### PR DESCRIPTION
Adds **Countersign** to Security & Ops.

A neutral control plane for AI agents that spend money: one declarative policy (caps, allow/denylists, approval thresholds) compiled to each wallet backend's native controls, a pre-flight guard on every x402/AP2 payment (`@countersign/x402`, `@countersign/ap2`), a sub-second cross-vendor kill switch, and an append-only Ed25519-signed audit ledger. Apache-2.0 open core, testnet-only today. Docs: https://countersign.network/docs/

(Prepared by an automated agent on behalf of the Countersign maintainer.)