### PR TITLE
Add China Source Intelligence x402 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [China Source Intelligence](https://github.com/quietvector-agent/china-source-intelligence-api) - Open-source Express and PayAI example for x402-gated Mandarin query planning and primary-source evidence bundles, with a live Base USDC custom-research route on [the402](https://the402.ai/catalog/service?id=svc_0beefffd53ac422e).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds an open-source Express/PayAI x402 example for Mandarin query planning and primary-source evidence bundles. The linked repository and live Base USDC research route are both public and currently reachable.