### PR TITLE
Add AgentServices to Ecosystem — x402-paid API platform for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [AgentServices](https://github.com/vbkotecha/aiservices-api) - Paid data APIs for AI agents with x402 on Base. 29 endpoints: crypto prices, DeFi yields, technical indicators, marketing intelligence, dispute resolution (AgentCourt engine). MCP endpoint at api.aiservices.to/mcp.
 - [CardZero](https://cardzero.ai)
+- [AgentServices](https://agentservices.to) — Paid API platform for AI agents with 54 services, 97 endpoints, and 41 x402-paid paths. Crypto market data, stock prices, FX rates, news, LLM inference, and image generation. 37 MCP tools. [MCP server](https://agentservices.to/mcp). USDC on Base.
 - [AgentCourt](https://github.com/vbkotecha/agentcourt-api) - Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet. The Evaluator layer for ERC-8183. - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
 ### Facilitators & Networks

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
-- [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [CardZero](https://cardzero.ai)
+- [AgentCourt](https://github.com/vbkotecha/agentcourt-api) - Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet. The Evaluator layer for ERC-8183. - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) - Paid data APIs for AI agents with x402 on Base. 29 endpoints: crypto prices, DeFi yields, technical indicators, marketing intelligence, dispute resolution (AgentCourt engine). MCP endpoint at api.aiservices.to/mcp.
 - [CardZero](https://cardzero.ai)
 - [AgentCourt](https://github.com/vbkotecha/agentcourt-api) - Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet. The Evaluator layer for ERC-8183. - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 


### PR DESCRIPTION
## What

Adding **AgentServices** ([agentservices.to](https://agentservices.to)) to the Ecosystem section.

## Why

AgentServices is a production x402-paid API platform for AI agents:

- **54 services**, **97 endpoints**, **41 x402-paid paths** (USDC on Base)
- **37 MCP tools** — listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0?search=agentservices) (`to.agentservices/agentservices`, v5.3.0)
- Categories: crypto market data, stock prices, FX rates, news, LLM inference, image generation
- x402 V2 compliant (`x402Version: 2`, `network: eip155:8453`)
- Live MCP endpoint: `https://agentservices.to/mcp`

## Where

Added under **Ecosystem** alongside other x402 API services (Strale, CardZero).