### PR TITLE
Add Agentcard to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Agentcard](https://agentcard.sh) - One-time virtual cards for AI agents. Fund a wallet, set spend caps and human approvals, and the agent mints a fresh single-use card to check out at any merchant that accepts cards. Complements x402 machine-native payments with a card rail; wallets funded via Coinbase CDP Onramp. Connect over a remote MCP server, REST API, or CLI. ([Docs](https://docs.agentcard.sh))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Agentcard to the **Ecosystem** section.

Agentcard issues one-time virtual cards for AI agents: fund a wallet, set spend caps and human-in-the-loop approvals, and the agent mints a fresh single-use card to check out at any merchant that accepts cards. It complements x402's machine-native payments by covering card-rail checkout, and funds agent wallets via Coinbase CDP Onramp. Agents connect over a remote MCP server, REST API, or CLI.

- Site: https://agentcard.sh
- Docs: https://docs.agentcard.sh
