### PR TITLE
Add Revenue Dojo x402 payment verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [Revenue Dojo Agent Payment Verifier](https://x402.167-172-95-184.nip.io/offers) - Live Base-USDC x402 API for buyer-agent payment, receipt, and mandate checks. Includes 10 paid routes (`/receipt/verify`, `/mandate/verify`, `/audit/x402`, `/mcp/call`), OpenAPI and `/llms.txt` quickstart, and cash-truth evidence grading for settlement tests.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds a live x402 Base-USDC service to the Example Apps section.

Verification before opening this PR:
- `GET /offers` returned 200 with the public offer catalog.
- `GET /llms.txt` returned 200 with buyer-agent quickstart instructions.
- `GET /price` returned HTTP 402 with x402 v2 payment requirements, as expected for a protected route.
- `GET /status/indexing` returned 200; current x402scan status is 10 registered routes, 0 failed, 0 warnings.

Cash-truth note: this listing is distribution only; it is not a revenue claim.