### PR TITLE
Add Eva MCP to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Eva MCP](https://api.ai.everything.inc/mcp) - Paid research agent for crypto, DeFi and global markets: one x402 call ($0.01 USDC on Arbitrum One or Base, v1 and v2) runs a multi-step agent over live market data and returns a plain-text answer. MCP endpoint with OpenAPI discovery at [/openapi.json](https://api.ai.everything.inc/openapi.json).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Eva MCP to the Ecosystem section: a paid research agent for crypto, DeFi and global markets. One x402 call ($0.01 USDC on Arbitrum One or Base, v1 and v2) runs a multi-step agent over live market data and returns a plain-text answer.

Primary sources: the live endpoint at https://api.ai.everything.inc/mcp (bare POST returns a 402 challenge) and its OpenAPI discovery document at https://api.ai.everything.inc/openapi.json. Already listed and verified on x402scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)