### PR TITLE
Add SolKnife to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [SolKnife](https://solknife.xyz/agents) - Non-custodial Solana toolkit exposed as 55 HTTP endpoints and an MCP server, 32 of them x402-paid: token rug-checks, Jupiter swaps, portfolios, SPL/Token-2022 minting, and Squads multisig. Settles USDC on Solana mainnet through its own facilitator.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
[SolKnife](https://solknife.xyz/agents) is a non-custodial Solana toolkit reachable as plain HTTP and over MCP.

- **55 endpoints, 32 x402-paid** at $0.01 USDC per call on Solana mainnet, settled through a self-hosted facilitator.
- **MCP server** at `/api/mcp` (streamable HTTP), listed in the official MCP registry as `xyz.solknife/toolkit`. Connecting and `tools/list` aren't charged, so an agent can browse the catalog before it buys.
- Covers token rug-checks, Jupiter swaps, portfolios, LP positions, DLMM pools, SPL/Token-2022 mint lifecycle, Squads v4 multisig, and Arweave uploads.
- Every write is two-step and non-custodial: `/build` returns an unsigned transaction, you sign it, `/execute` submits it.

Spec at https://solknife.xyz/openapi.json. Already listed on [x402scan](https://www.x402scan.com/server/e7fbdc99-eed9-4b33-b14e-e86f4ba76101).

One line, appended to the end of `### Ecosystem` so the existing order is untouched.