### PR TITLE
Update README with Reputa details

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- - [Reputa](https://reputa.xyz) - Neutral on-chain risk intelligence for AI agents: wallet Security/Risk/Reputation scores (crisis behaviour, ERC-20 approvals, flagged-address contact, Safe checks) and DeFi cover (insurance) analyses (Assecura score, coverage gap map, claims history, red flags). Free discovery + teasers; deep reports paid per call via x402 (USDC on Polygon + Base). [MCP server](https://www.npmjs.com/package/reputa-mcp) available. ([Manifest](https://reputa.xyz/.well-known/x402.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Reputa to Ecosystem.

Reputa is neutral on-chain risk intelligence for AI agents:
- Wallet Security/Risk/Reputation scores (crisis behaviour, ERC-20 approvals, contact with flagged addresses, Safe/Gnosis checks)
- DeFi cover (insurance) analyses: Assecura score 0-100, coverage gap map (what pays vs what is excluded), claims/payout history, red flags

Free discovery + teasers; deep reports paid per call via x402 (USDC on Polygon + Base). Self-hosted facilitator, no accounts.

- Manifest: https://reputa.xyz/.well-known/x402.json
- OpenAPI: https://reputa.xyz/openapi.json
- Cover catalog (free): https://reputa.xyz/api/cover/v1/analyses
- MCP: reputa-mcp (npm) / io.github.0xthaner/reputa