### PR TITLE
Add MeshPilot to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
+- [MeshPilot](https://meshpilot.cc) - Text/image to production 3D models (GLB, PBR textures) for AI agents, paid per call with x402 USDC on Solana; includes auto-rigging and open-vocabulary part segmentation.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.


### PR DESCRIPTION
Adds [MeshPilot](https://meshpilot.cc) - an x402-native API that turns text or images into production-ready 3D models (GLB, PBR textures, up to 1M triangles).

- Pay per call in USDC on Solana via x402 (settle-upfront, auto-refund on failure): an unpaid call returns 402 with terms, no account needed
- Self-describing discovery endpoint for agents: `GET https://meshpilot.cc/api/generate` (live prices, every knob, examples)
- Also offers auto-rigging (skeleton + skinning) and open-vocabulary part segmentation, each a paid x402 call

Live and in production.