### PR TITLE
Add Watchtower — sanctions & export-control screening API for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
+- [Watchtower](https://watchtower-api.com) - Deterministic sanctions & export-control screening for AI agents: OFAC, UN, EU, UK, Canada, Australia + US BIS/State export lists (~48,000 parties, refreshed daily). Typo/alias/non-Latin-tolerant matching, reproducible auditable results. Pay per call via x402 (USDC on Base), [MCP](https://watchtower-api.com/mcp), or API key. [Docs](https://watchtower-api.com/docs).
+
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)


### PR DESCRIPTION
Adds **Watchtower** to the Ecosystem section — a single line following the existing format.

Deterministic sanctions & export-control screening built for AI agents: OFAC (SDN + Consolidated), UN, EU, UK OFSI, Canada, Australia, plus US BIS/State export-control lists (~48,000 parties, refreshed daily). Pay per call via x402 (USDC on Base), a remote MCP server, or an API key.

- Live: https://watchtower-api.com · Docs: https://watchtower-api.com/docs
- x402: /v1/screen returns a standard 402 challenge (Base USDC)
- MCP (streamable HTTP): https://watchtower-api.com/mcp
- In the official MCP Registry (com.watchtower-api/sanctions-screening)

Thanks for maintaining this list!