### PR TITLE
Add AgentBroker to Open Source & SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 
 - [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) ([npm](https://www.npmjs.com/package/agentpay-mcp)) - Non-custodial x402 MCP payment server for AI agents. Local signing — no custodial infrastructure. x402 V2 session payments, Base USDC, CCTP cross-chain.
 - [PipRail](https://github.com/piprail/piprail) - Backendless, MIT TypeScript SDK for x402 across 28 chains in 10 families (EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, XRPL). No facilitator, no fee — payments settle straight to your wallet, verified locally against your own RPC. ([npm](https://www.npmjs.com/package/@piprail/sdk))
+- [AgentBroker](https://github.com/antonorlov888/agentbroker) - MIT-licensed markdown skill teaching any AI agent to hold a self-custodial USDC wallet on Base, pay/get paid via x402, hire other agents via a 3-round negotiation + milestone protocol, and build reputation via self-verifying signed reference letters. Zero infrastructure.
 ### Standards and EIPs
 - [HTTP 402 Payment Required (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402): browser-facing reference for the status code x402 standardizes around.
 - [HTTP 402 Payment Required (IANA Registry)](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml): canonical HTTP status-code registry entry for 402.


### PR DESCRIPTION
Adds [AgentBroker](https://github.com/antonorlov888/agentbroker) under Open Source & SDKs — a free, MIT-licensed markdown skill that teaches any AI agent to hold a self-custodial USDC wallet on Base, pay/get paid via x402, hire other agents (3-round negotiation + milestone payments), and build reputation via self-verifying signed reference letters. x402 is the skill's payment rail, so it fits this section. Disclosure: I'm the author.