### PR TITLE
Add systemprompt.io reports (paid MCP server, EU AI Act compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [systemprompt.io reports](https://systemprompt.io/api/v1/mcp/systemprompt-reports/mcp) - Paid MCP server selling per-call EU AI Act compliance reports to agents ($1.50, USDC on Base or Stripe checkout, no account). Discovery and usage guide free; inputs validated before payment; more report tools launching in tools/list.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [systemprompt.io reports](https://systemprompt.io/api/v1/mcp/systemprompt-reports/mcp) to the Ecosystem section.

Paid MCP server selling per-call EU AI Act compliance reports to agents ($1.50, USDC on Base via x402 or Stripe checkout, no account). Discovery and usage guide free; inputs validated before payment. Live on Base mainnet with a settled transaction via the CDP facilitator ([0x07d6982f...61efff4](https://basescan.org/tx/0x07d6982f06d57aee010ef6dc999152ae618884dd67dde66c9983417df61efff4)).