### PR TITLE
Add meter402 (streaming/metered settlement for x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402-payments (QuickNode)](https://github.com/quiknode-labs/x402-payments) - Ruby gem for generating signed payment HTTP headers and links using the X402 protocol
 - [MoltPe (AI agent payment infrastructure)](https://github.com/umangbuilds/moltpe-agent-payments) - Non-custodial agent wallets with Shamir key splitting, programmable spending policies, and tri-rail support: x402 (HTTP-native), MPP (session-based), and fiat. 11 MCP tools for Claude Desktop, Cursor, Windsurf. Sub-second settlement on Polygon PoS, Base, Tempo. Free tier, no credit card. ([Site](https://moltpe.com))
 - [Routeweiler](https://github.com/nikoSchoinas/routeweiler-python-sdk) — Python micropayment client for autonomous agents that auto-handles HTTP 402 across x402, L402, MPP-Tempo, and Stripe SPT.
+- [meter402](https://github.com/Risingtell/meter402) — Per-second *streaming* settlement for x402: turns one-shot 402 calls into pay-as-you-consume metered billing (pay a tick, get the next chunk; stop paying, the gate shuts). Framework-free TypeScript core with an Express adapter and an MCP server so agents open a session and pay tick-by-tick, plus an EVM on-chain verifier that re-derives every settlement total straight from the token's Transfer ledger. MIT.
 
 
 


### PR DESCRIPTION
Adds **meter402** under **Open Source & SDKs**.

[meter402](https://github.com/Risingtell/meter402) is an MIT, framework-free TypeScript library that adds **per-second streaming settlement** on top of x402 — every other entry in this section handles one-shot 402 calls, so this fills the pay-as-you-consume / metered gap.

- Core `StreamingMeter` (pluggable store + settlement provider), one-line **Express** adapter, and an **MCP server** so agents open a session and decide tick-by-tick whether to keep paying.
- **EVM on-chain verifier** that re-derives every settlement total straight from the token's Transfer ledger (feed can never over-claim).
- Extracted and generalized from a live Casper streaming-payments project; typechecks and runs end-to-end.

Grouped under the existing Open Source & SDKs section, single high-signal entry per the contributing guidelines.