### PR TITLE
Add Firmata Protocol to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Firmata Protocol](https://firmata.ai) - On-chain Know Your Agent (KYA) trust layer above x402: pairs x402 settlement with verified identity (ERC-8004) and conditional escrow (ERC-8183), so each payment is bound to a verified counterparty and a job that completes or refunds. On Arc and Base testnets. Built by Meridian Finance.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Added Firmata Protocol entry with details on KYA trust layer under Ecosystem. 
Firmata is a trust layer above x402: 
it pairs x402 settlement with ERC-8004 identity and ERC-8183 escrow, so a payment is tied to a verified counterparty and a job that completes or refunds. It is not a facilitator or rail. 
Public links: firmata.ai, github.com/MeridianFinance/meridian-ecosystem. Stage: testnet on Arc and Base.