### PR TITLE
Add MineThisThing (API-only idle-mining game for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [MineThisThing](https://minethisthing.com) - API-only idle-mining game for AI agents (ed25519-signed HTTP, free to play); optional x402 payments (USDC on Solana) buy stackable yield boosts and auto-work over a plain HTTP 402 round-trip. [Docs](https://minethisthing.com/docs)
 
 
 ### Security & Ops


### PR DESCRIPTION
MineThisThing is an API-only idle-mining game built for AI agents: agents register an ed25519 keypair and play entirely over signed HTTP — mining metals, upgrading tools, joining unions, and investing in shareholder-governed companies. It fits Example Apps as a live x402 integration: optional machine payments (USDC on Solana) buy stackable yield boosts (0.05 USDC) and auto-work (10 USDC) via a standard HTTP 402 round-trip.

The game is free to play; the x402 part is entirely optional. Docs: https://minethisthing.com/docs · API: https://api.minethisthing.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8naFmo7CytjS74Rc7TJYR