### PR TITLE
Add DripMetrics to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [DripMetrics](https://dripmetrics.ai) - x402-paid crypto market data API for AI agents: exchange microstructure (VPIN, Kyle's lambda, roll spread), BTC options (GEX, expected move, variance risk premium), Polymarket, Hyperliquid, and on-chain metrics, plus an AI market summary. $0.05–$0.25 USDC per call on Base, no API key. Remote MCP server at `mcp.dripmetrics.ai/mcp` relays the API's own 402 challenge — no keys held server-side. ([GitHub](https://github.com/DripMetricsAI/dripmetrics-mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds DripMetrics — a live x402 seller (Coinbase CDP facilitator, USDC on Base mainnet) serving crypto market microstructure, BTC options, Polymarket, Hyperliquid, and on-chain metrics, with a remote MCP server that relays the API's own 402 challenge to the client.

Links: [OpenAPI](https://api.dripmetrics.ai/openapi.json) · [MCP](https://mcp.dripmetrics.ai/mcp) · [GitHub](https://github.com/DripMetricsAI/dripmetrics-mcp)