### PR TITLE
Add SFtunes to Example Apps: mixtapes at $0.01/tape via x402 (REST + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [SFtunes](https://sftunes.com) - Friends-mixtape app whose public tape catalog is a live x402 storefront: hand-made mixtapes with liner notes at $0.01 USDC per request on Base (REST + paid MCP server), with 80% of each payment shared to the human tapemaker. [Pricing](https://sftunes.com/api/tapes/pricing) | [MCP](https://sftunes.com/api/mcp)
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds [SFtunes](https://sftunes.com) to Example Apps: a friends-mixtape app whose public catalog is a live x402 storefront on Base mainnet (CDP facilitator, Bazaar discovery declared). $0.01 USDC per request over REST and a paid MCP server; 80% of tape-attributed payments accrue to the human tapemaker. Free terms endpoint at https://sftunes.com/api/tapes/pricing — the 402 is live: `curl -i https://sftunes.com/api/tapes`. No duplicate in the list; one resource, one PR.