### PR TITLE
Add eltociear Security & Data x402 API suite (Example Apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Vercel x402 AI Starter](https://vercel.com/templates/ai/x402-ai-starter) - Full-stack Next.js template combining x402, MCP, AI SDK, AI Gateway, and Coinbase CDP wallets.
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [eltociear Security & Data APIs](https://eltociear-skill-audit.hf.space) – Live x402 API suite for agents: `skill-audit` scans text, URLs, and whole GitHub repos for malicious AI-skill & supply-chain patterns; `clean-read`/`extract`/`pdf` turn web pages into clean Markdown or structured data; `headers`/`dns` grade HTTP-security posture; plus `tokenguard` (ERC-20 rug/honeypot scans, 6 chains) and `contract-guard` (EVM contract risk). USDC on Base, no signup, per-call ($0.005–$0.05).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds a single entry under **Example Apps** for a live x402 API suite aimed at agents.

- `skill-audit` — scan text, URLs, and whole public GitHub repos for malicious AI-skill / prompt-injection / supply-chain patterns
- `clean-read` / `read/batch` / `extract` / `pdf` — web pages → clean Markdown or structured metadata (OpenGraph/JSON-LD), PDF → text
- `headers` / `dns` — HTTP security-header grading + DNS/SPF/DMARC posture
- `tokenguard` (ERC-20 rug/honeypot scans, 6 chains) and `contract-guard` (EVM contract risk)

All live now, USDC settlement on Base via x402 v2, no signup, $0.005–$0.05 per call. Complements the existing `x402-approval-guard` entry (that's a library pattern; this is the hosted API suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)