### PR TITLE
Update README.md, Add Mart402 to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Mart402](https://mart402.com) - Web content extraction API for AI agents: URL to Markdown with metadata, JS rendering included. Pay-per-call x402 on Base mainnet, no API key. Machine docs at `/llms.txt`, hosted MCP at `/mcp` (listed on the official MCP registry as `com.mart402/extract`).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adding Mart402 — a web content extraction API for AI agents with x402 pay-per-call on Base mainnet. Spec-compliant v1 402 responses (verified with the official x402 Python client), hosted MCP endpoint, and machine-readable docs (/llms.txt, /.well-known/ai-catalog.json). Also listed on the official MCP registry as com.mart402/extract.