### PR TITLE
feat(ecosystem): add TerraDeed with MCP server install

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [TerraDeed](https://terradeed.co.uk) - Web scraping and structured data extraction API. Two endpoints: `POST /scrape` (clean LLM-ready markdown, $0.01 USDC) and `POST /extract` (schema-driven structured JSON, $0.05 USDC). Both live on Base mainnet, indexed in CDP Bazaar. MCP server: `npx terradeed-mcp-server`. [GitHub](https://github.com/terradeed/terradeed-scraper)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds TerraDeed Labs to the ecosystem section.

- POST /scrape — clean LLM-ready markdown, $0.01 USDC
- POST /extract — schema-driven structured JSON, $0.05 USDC
- Both endpoints live on Base mainnet, indexed in CDP Bazaar
- MCP server: `npx terradeed-mcp-server`
- GitHub: https://github.com/terradeed/terradeed-scraper