### PR TITLE
Add Central Command — x402 trading API + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
+- [Central Command](https://github.com/tlefko/central-command) - 39-endpoint crypto trading intelligence API + MCP. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. ([MCP](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/mcp) | [Docs](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs) | [Catalog](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-gateway/catalog))
+
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)
 - [Supported Networks](https://docs.cdp.coinbase.com/get-started/supported-networks#x402)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
-- [Central Command](https://github.com/tlefko/central-command) - 39-endpoint crypto trading intelligence API + MCP. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. ([MCP](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/mcp) | [Docs](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs) | [Catalog](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-gateway/catalog))
+- [Central Command](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs) - 39-endpoint crypto trading intelligence API + MCP. Pay-per-use x402 (Base USDC) or prepaid X-Api-Key. ([MCP](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/mcp) | [Docs](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-docs) | [Catalog](https://rtcelwjnrbmfmrywacky.supabase.co/functions/v1/x402-gateway/catalog))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Central Command under Ecosystem.

Production x402 surface: 39 endpoints, Base USDC pay-per-use, prepaid keys, remote MCP.