### PR TITLE
Add VoiceGate to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [VoiceGate](https://aivoicegate.com) - Voice/telephony layer for autonomous agents. The agent places a real PSTN phone call and pays per minute itself in USDC over x402, and authenticates with a verifiable credential (KYA, aligned with ERC-8004) so the callee can verify which agent is calling. Model-agnostic — bring your own LLM via webhook. MIT SDK for Python and Node; hosted call API in private beta. ([SDK](https://github.com/CallsFlow/voicegate-sdk)) ([PyPI](https://pypi.org/project/voicegate/)) ([npm](https://www.npmjs.com/package/voicegate))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **VoiceGate** to the *Ecosystem* section.

Voice/telephony layer for autonomous agents: the agent places a real PSTN phone call and settles the per-minute cost itself in USDC over x402, and authenticates with a verifiable credential (KYA, aligned with ERC-8004) so the callee can verify which agent is calling. Model-agnostic — bring your own LLM via webhook.

The x402 entries in this list are data, compute and wallet services. This is the telephony primitive: as far as I can tell, the only x402-native way for an agent to pay for a phone call.

Status is stated honestly in the entry — the SDK is MIT and installable today (`pip install voicegate` / `npm i voicegate`), the hosted call API is in private beta.

- Site: https://aivoicegate.com
- SDK: https://github.com/CallsFlow/voicegate-sdk
- PyPI: https://pypi.org/project/voicegate/ · npm: https://www.npmjs.com/package/voicegate

One item, grouped under an existing section, links checked.
