### PR TITLE
Add x402-farm to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [x402-farm](https://api.x-402.online) - 85 pay-per-call tools for AI agents: crypto honeypot/rug-pull checks (verdict OK/CAUTION/HIGH_RISK/AVOID before you trade, 8 chains), residential-IP web scraping that reaches sites blocking datacenter/cloud scrapers, DeFi & market data, and global company data (US SEC EDGAR / UK Companies House / FR SIREN-KYB). x402 USDC on Base, OpenAPI with per-route x-payment-info. [MCP server](https://smithery.ai/server/laurenthalbrun/x402farm) · [npm](https://www.npmjs.com/package/x402farm-mcp).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **x402-farm** to the Ecosystem section.

10 pay-per-call APIs for AI agents (USDC on Base, exact scheme, CDP facilitator): web extraction to markdown (JS-rendered via real browser), screenshots, PDF, links, SEO/OpenGraph meta, full DNS, email validation, French company registry lookup (SIREN/officers/status) and French/overseas geocoding.

- Live: https://x402-farm.vercel.app
- Machine-readable: `/`, `/llms.txt`, `/openapi.json`
- Free preview routes so agents can try before paying
- Included MCP server (10 tools) for Claude/Cursor
- Already listed on x402scan

Repo: https://github.com/Ghost11777/x402-farm