### PR TITLE
Add AI Rook Agentic Escrow — on-chain USDC escrow for agent commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,4 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 This list is offered under CC0; see upstream specs for their respective licenses.
 
 - [AgentBridge](https://github.com/tianzizhiming-svg/agentbridge) — Pay-per-fetch gateway for Chinese web content (Xiaohongshu, Zhihu, etc.). Returns clean markdown, settled in USDC on Base via x402.
+- [AI Rook](https://agents.ai-rook.com) — Live x402 trading intelligence API. Market pulse, trade signals, order flow analysis, AI chart analysis, backtesting, liquidation heatmap. 10 endpoints, USDC on Base mainnet, CDP Bazaar listed.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Reddit – r/x402](https://www.reddit.com/r/x402/)
 - [Discord – Coinbase Developer Platform](https://discord.com/invite/cdp)
 
+### Services
+- [AI Rook Agentic Escrow](https://github.com/Ai-Rook/agentic-escrow) — On-chain USDC escrow for agent-to-agent commerce on Base. 0.5% fee, UUPS upgradeable, x402-compatible.
+
 ### Contributing
 - Add high-signal links: specifications, reference implementations, deep-dive posts, audits, and example apps.
 - Prefer primary sources and canonical specifications.


### PR DESCRIPTION
## AI Rook Agentic Escrow

On-chain USDC escrow for agent-to-agent commerce on Base mainnet.

- Contract: `0xDb8dd1bf2a0D44552b2C7e83Fb56443e75522Ed8` (UUPS proxy)
- Fee: 0.5% on release
- Chain: Base (8453)
- API: https://agents.ai-rook.com/api/escrow
- Repo: https://github.com/Ai-Rook/agentic-escrow

Added under new **Services** section.