### PR TITLE
Add AgentServices to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
-- [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [CardZero](https://cardzero.ai)
+- [AgentCourt](https://github.com/vbkotecha/agentcourt-api) - Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet. The Evaluator layer for ERC-8183. - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Ecosystem Directory](https://www.x402.org/ecosystem)
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
+- [AgentServices](https://github.com/vbkotecha/aiservices-api) - Paid data APIs for AI agents with x402 on Base. 29 endpoints: crypto prices, DeFi yields, technical indicators, marketing intelligence, dispute resolution (AgentCourt engine). MCP endpoint at api.aiservices.to/mcp.
 - [CardZero](https://cardzero.ai)
 - [AgentCourt](https://github.com/vbkotecha/agentcourt-api) - Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet. The Evaluator layer for ERC-8183. - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
 


### PR DESCRIPTION
Adding AgentServices (agentservices.to) to the Ecosystem section. AgentServices is an x402-paid API marketplace for AI agents with 54 services, 97 endpoints, 41 x402-paid endpoints (USDC on Base), and an MCP server with 37 tools listed on the official MCP Registry. Fits alongside Strale and CardZero as a production x402 service.