### PR TITLE
Add read402: pay-per-call URL to Markdown extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,4 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 This list is offered under CC0; see upstream specs for their respective licenses.
 
 - [AgentBridge](https://github.com/tianzizhiming-svg/agentbridge) — Pay-per-fetch gateway for Chinese web content (Xiaohongshu, Zhihu, etc.). Returns clean markdown, settled in USDC on Base via x402.
+- [read402](https://read402.fly.dev) — Pay-per-call URL to clean Markdown extraction (Readability + Turndown), $0.02 USDC on Base mainnet via x402.org facilitator, no signup or API key. ([GitHub](https://github.com/wxtest-prog/read402))


### PR DESCRIPTION
Adds read402 (https://read402.fly.dev) — a small x402 resource server that extracts any URL into clean Markdown via Readability + Turndown. $0.02 USDC per call on Base mainnet, spec-compliant 402 challenge/X-PAYMENT flow, no signup. Source: https://github.com/wxtest-prog/read402