### PR TITLE
Add Kelam — real phone calls for AI agents (x402, live on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Kelam](https://pay.kelam.sh) - Real phone calls for AI agents on Base. Give a number and a task ("call this restaurant and book a table for 4 at 7pm") and a voice AI makes the call and returns the outcome + transcript; also provision your own inbound/outbound voice agents and drive the agent builder. Metered per-minute, pay-per-use in USDC via x402, no account or API key. ([OpenAPI](https://pay.kelam.sh/openapi.json) | [llms.txt](https://pay.kelam.sh/llms.txt))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **Kelam** under Ecosystem.

Live at https://pay.kelam.sh — agents give a number + a task ("call this restaurant and book a table for 4 at 7pm") and a voice AI makes the real call and returns the outcome + transcript; agents can also provision their own inbound/outbound voice agents and drive the builder. Pay-per-use USDC via x402 on Base, no account/API key. Discovery at /openapi.json + /llms.txt.