### PR TITLE
Add NEAR and Base x402 Facilitator to Facilitators & Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
 - [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
+- [NEAR x402 Facilitator](https://x402.mikedotexe.com/supported) - Independent x402 facilitator for NEAR mainnet and testnet; NEP-141 USDC settled through NEP-366 signed delegates with relayer-sponsored gas.
 
 
 ### Open Source & SDKs

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
 - [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
-- [NEAR x402 Facilitator](https://x402.mikedotexe.com/supported) - Independent x402 facilitator for NEAR mainnet and testnet; NEP-141 USDC settled through NEP-366 signed delegates with relayer-sponsored gas.
+- [NEAR x402 Facilitator](https://x402.mikedotexe.com/) - Open-source, API-key-gated facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery.
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Adds the **NEAR x402 Facilitator** — an independent, open-source production x402 facilitator now serving NEAR mainnet, NEAR testnet, and Base mainnet from one durable settlement engine: <https://x402.mikedotexe.com/>.

The service supports canonical x402 v2 `exact` Circle USDC payments on both chain families, with relayer-sponsored gas, API-key-gated access, and durable recovery. Public paid reference workloads are available for [NEAR](https://x402-demo.mikedotexe.com/work) and [Base](https://x402-demo-base.mikedotexe.com/work).

Source: <https://github.com/fastnear/x402-near-facilitator>  
Signed v0.5.1 release: <https://github.com/fastnear/x402-near-facilitator/releases/tag/v0.5.1>  
Sanitized rollout evidence: <https://github.com/fastnear/x402-near-facilitator/blob/main/docs/evidence/2026-07-26-v051-reference-deployment.md>

NEAR indexing in x402scan remains tracked separately in Merit-Systems/x402scan#1040.