### PR TITLE
Add Macro Pulse to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+-  [Macro Pulse](https://macro-pulse-x402.onrender.com) - Pay-per-call macroeconomic data API. GDP growth, inflation, and unemployment history plus a computed momentum score for any country, sourced from World Bank Open Data. $0.02 USDC per call on Base mainnet, no API keys or subscriptions.
+
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds Macro Pulse, a live pay-per-call macroeconomic data API (World Bank data, $0.02 USDC/call on Base mainnet via x402).