### PR TITLE
Add Rubric Protocol to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+ - [Rubric Protocol](https://rubric-protocol.com/x402.html) - Post-quantum AI attestation over x402. $0.005 USDC on Base per attestation (ML-DSA-65, FIPS 204), anchored to Hedera Consensus Service mainnet; free public verification with no account. Signed monthly agent spend statements at $0.50. ([manifest](https://rubric-protocol.com/.well-known/x402.json))
+
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Rubric Protocol — post-quantum (ML-DSA-65 / FIPS 204) attestation service paid via x402, live on Base mainnet with Hedera HCS anchoring. Verification is free and public, so any record can be independently checked without trusting the service. Manifest: https://rubric-protocol.com/.well-known/x402.json