### PR TITLE
Add MIDAX402 to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [MIDAX402](https://midax402.com) - x402 ecosystem intelligence for AI agents: pay-per-query curated answers about x402 services, facilitators, security, and market activity (4 tiers, $0.03–$0.15 USDC), plus a cryptographically signed verification registry of 198+ probed x402 services. Live on Base Mainnet and Algorand Mainnet (GoPlausible).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adding MIDAX402 (x402 ecosystem intelligence API). Live on Base Mainnet and Algorand Mainnet (GoPlausible). Includes well-known configuration at https://midax402.com/.well-known/x402.json