### PR TITLE
Add Firmbrain to the ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [Firmbrain](https://agents.firmbrain.ai) - The only x402 service built for Robinhood Chain (chainId 4663): RPC, on-chain data, tokenized-stock registry, USDG stats, address webhooks, and LLM inference payable in USDG on Robinhood Chain - plus a 147-tool onchain & trading-intelligence suite (safety, compliance, perps, options, portfolio). Settles in USDC on Base/Polygon/Arbitrum/Solana or USDG on Robinhood Chain. MCP server at /mcp. ([repo](https://github.com/bkrigmo1/robinhood-chain-x402))
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.


### PR DESCRIPTION
Adds Firmbrain to the Ecosystem section. It's the only x402 service built for Robinhood Chain (chainId 4663) — live x402 API + MCP server exposing 147 pay-per-call tools (RPC/data, tokenized-stock registry, USDG stats, webhooks, plus safety, compliance, perps, options, portfolio, and LLM inference payable in USDG). Settles in USDC on Base/Polygon/Arbitrum/Solana or USDG on Robinhood Chain. Public repo: https://github.com/bkrigmo1/robinhood-chain-x402