### PR TITLE
Add Stelar Digital to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Stelar Digital](https://api.stelardigital.com) - Live crypto grid-trading telemetry, grid-parameter recommendations, market-regime classification, and sentiment scoring via x402. 8 pay-per-call endpoints, $0.005-$2.50 USDC on Base, from a real production grid-trading operation. Built by one human + one AI.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Stelar Digital (https://api.stelardigital.com) under Ecosystem.

8 x402-payable endpoints ($0.005-$2.50 USDC on Base): live grid-trading P&L telemetry from a real production trading operation, grid-parameter recommendations, market-regime classification, sentiment scoring, price data, risk. x402 discovery at https://api.stelardigital.com/.well-known/x402. Built by one human + one AI.