### PR TITLE
Add Solinkify (Solana-native x402 stack) to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Solinkify](https://solinkify.com/agentic) - Solana-native x402 stack: a paywall with non-custodial escrow settlement (99% to the creator, one Anchor program), 15 integrations from JS/Python middleware to WordPress, Kong and a reverse proxy, pre-paid and subscription modes for high-volume agents, plus agent-side tooling ([MCP server](https://github.com/Zenidp/solinkify-mcp), 15 tools with spending caps) and a marketplace of x402-priced APIs. Live 5-minute walkthrough with a real on-chain payment.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Solinkify under Ecosystem.

Solana-native x402: HTTP 402 plus an x402 v2 manifest on the server side, non-custodial escrow settlement through a single Anchor program (99% to the creator), agent-side MCP tooling with fail-closed spending caps, and a directory of x402-priced APIs for discovery. Pre-paid balances and on-chain subscriptions cover the high-frequency machine buyers that dominate x402 volume.

Live proof, no signup: https://solinkify.com/agentic — an agent pays a real paywall on devnet.