### PR TITLE
Add Transcribe to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Hyperbolic x402 Chat API (LLM Pay-per-Request)](https://github.com/HyperbolicLabs/hyperbolic-x402)
 - [CoinMarketCap x402 API](https://coinmarketcap.com/api/documentation/ai-agent-hub/skills/cmc-x402) - Pay-per-request crypto market data and MCP access over x402 with USDC settlement on Base.
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and wallets, with x402 pay-per-call endpoints on Base.
+- [Transcribe](https://transcribe.soboljem.cz) - Audio URL in; transcript, WebVTT subtitles, and an editor's cut list (where the dead air is and how much shorter the result would be) out. Quoted per file from `content-length` rather than a flat fee, in USDC on Base.
 - [Pinata – Pay to Pin on IPFS with x402](https://pinata.cloud/blog/pay-to-pin-on-ipfs-with-x402/)
 - [Pinata 402-server (Code)](https://github.com/PinataCloud/402-server)
 - [Pinata – Monetize AI Hardware (Jetson) with x402](https://pinata.cloud/blog/using-x402-to-monetize-ai-hardware/)


### PR DESCRIPTION
Adds one line to **Example Apps**.

[Transcribe](https://transcribe.soboljem.cz) takes an audio URL and returns the transcript, ready-made WebVTT subtitles, and an editor's cut list — where the dead air is, and how much shorter the result would be.

Two things that might be of interest beyond it being another paid endpoint:

- **Priced per file, not per request.** The quote is computed from the source's `content-length` before the 402 goes out, so a three-minute clip is not charged like a half-hour interview. A `POST` with no body still returns a valid 402 at the floor price, so indexers can probe it.
- **The cut list is the actual product.** Whisper segments are turned into keep/cut spans using thresholds tuned by hand on real two-person footage (0.6 s merge, 0.15 s padding, 0.4 s minimum keep). Measured against that hand-tuned audio VAD on a mixed track, the segment-derived spans landed within 1.9 percentage points.

Discovery document: `https://transcribe.soboljem.cz/.well-known/x402`
Settlement: USDC on Base mainnet via the PayAI facilitator.