### PR TITLE
Add modelprices.xyz to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [modelprices.xyz](https://github.com/pennyforgehq/modelprices) - Open-source production x402 seller: normalized LLM price and capability data for 2,000+ models across 70+ providers, per-call USDC pricing ($0.002-$0.02 on Base) with Bazaar discovery extensions, free preview twins, llms.txt agent playbook, and an MCP server. [Live](https://modelprices.xyz)
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds modelprices.xyz — an open-source production x402 seller (normalized LLM market data, per-call USDC on Base) with Bazaar discovery extensions, MCP server, and llms.txt agent playbook. Registered on x402scan; source at github.com/pennyforgehq/modelprices.