### PR TITLE
Add ManyHands Evidence API to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [ManyHands Evidence API](https://manyhands.uk/evidence-api/) - Deterministic snapshots, change checks, deadline scans, citation packs, and PDF evidence for supported UK official sources, payable per call with Base USDC via x402 v2. ([Catalog](https://api.manyhands.uk/catalog) | [OpenAPI](https://api.manyhands.uk/openapi.json))
 
 
 ### Security & Ops


### PR DESCRIPTION
## Summary

- add the ManyHands Evidence API to Example Apps
- describe its deterministic UK official-source evidence products and x402 v2 payment rail
- link its public catalog and OpenAPI specification

## Validation

- documentation, catalog, and OpenAPI links return HTTP 200
- an unpaid request to the public API returns the expected HTTP 402 payment challenge
- the README does not already contain a ManyHands entry
