### PR TITLE
Add GBLIN to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [GBLIN](https://gblin.digital) - NAV-backed basket token on Base (cbBTC/WETH/USDC) with an automated on-chain crash-response policy. 11 x402 pay-per-call endpoints (treasury state, quotes, JIT redemption calldata, risk attestation) settled via CDP, plus a free read-only [MCP server](https://www.npmjs.com/package/@gblin-protocol/mcp-server) and machine-readable discovery at [`/.well-known/x402`](https://gblin.digital/.well-known/x402).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds GBLIN: a live x402 service suite on Base — NAV-backed basket token with an automated on-chain crash-response policy, 11 CDP-settled pay-per-call endpoints, free read-only MCP server, machine-readable discovery manifest.