### PR TITLE
Add Token Risk x402 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
-- [Token Risk & DeFi Pool Intelligence](https://5-9-107-124.nip.io) - Read-only
-  risk APIs for agents: [token risk](https://5-9-107-124.nip.io/token-risk?chain=base)
+- [CapGain Safety & Work Artifacts](https://5-9-107-124.nip.io) - Read-only
+  APIs for agents: [token risk](https://5-9-107-124.nip.io/token-risk?chain=base)
   ($0.01 USDC) and [DeFi pool analysis](https://5-9-107-124.nip.io/defi-pool?chain=base)
-  ($0.02 USDC), paid per call on Base through x402 with no API key or signup.
+  ($0.02 USDC), plus machine-buyable invariant tests ($0.03), repository reviews
+  ($0.05), and protocol research ($0.03), paid per call on Base through x402
+  with no API key or signup.
   ([Discovery](https://5-9-107-124.nip.io/.well-known/x402.json) |
   [OpenAPI](https://5-9-107-124.nip.io/openapi.json))
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
-- [Token Risk](https://5-9-107-124.nip.io) - Read-only Base and Ethereum
-  contract-risk API for agents, paid per call in Base USDC through x402.
-  Reports bytecode, upgradeability, owner/admin, mint, pause, blacklist, fee,
-  and honeypot indicators; no API key or signup.
+- [Token Risk & DeFi Pool Intelligence](https://5-9-107-124.nip.io) - Read-only
+  risk APIs for agents: [token risk](https://5-9-107-124.nip.io/token-risk?chain=base)
+  ($0.01 USDC) and [DeFi pool analysis](https://5-9-107-124.nip.io/defi-pool?chain=base)
+  ($0.02 USDC), paid per call on Base through x402 with no API key or signup.
   ([Discovery](https://5-9-107-124.nip.io/.well-known/x402.json) |
   [OpenAPI](https://5-9-107-124.nip.io/openapi.json))
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [Token Risk](https://5-9-107-124.nip.io) - Read-only Base and Ethereum
+  contract-risk API for agents, paid per call in Base USDC through x402.
+  Reports bytecode, upgradeability, owner/admin, mint, pause, blacklist, fee,
+  and honeypot indicators; no API key or signup.
+  ([Discovery](https://5-9-107-124.nip.io/.well-known/x402.json) |
+  [OpenAPI](https://5-9-107-124.nip.io/openapi.json))
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.


### PR DESCRIPTION
Adds a concise ecosystem entry for the live Token Risk service. The production endpoint exposes public x402 discovery and OpenAPI metadata and returns an unpaid Base-mainnet USDC 402 challenge without API keys or signup.