### PR TITLE
Add x402 FixSpec remediation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 ### Ecosystem
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
+- [x402 FixSpec](https://github.com/am5188/x402-fixspec) - Open-source deterministic endpoint conformance and remediation tool: inspects unpaid challenges, validates Base USDC requirements, probes discovery documents, and returns OpenAPI, Bazaar, and agent-instruction fix templates. ([Live API](https://web3-fixspec.esan5188.workers.dev/)) ([x402 offer](https://payanagent.com/x402/kh7cpz6bqrv558bwvg09g84wq58bckmf))
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [Pyrimid](https://pyrimid.ai/) - Agent-to-agent commerce infrastructure for x402 and ERC-8004, with MCP-native service discovery and onchain payment splitting through PyrimidRouter. ([Proof](https://pyrimid.ai/proof))
 - [x402station](https://x402station.com/) - Analytics and monitoring platform for x402 services with real-time insights and performance tracking.


### PR DESCRIPTION
## Summary

Adds x402 FixSpec under Ecosystem. It is an open-source deterministic tool that inspects unpaid x402 challenges, validates Base native-USDC requirements, probes discovery documents, and returns patch-ready OpenAPI/Bazaar/agent-instruction templates.

- Source and tests: https://github.com/am5188/x402-fixspec
- Live API and sample: https://web3-fixspec.esan5188.workers.dev/
- Receipt-bearing x402 offer: https://payanagent.com/x402/kh7cpz6bqrv558bwvg09g84wq58bckmf

Disclosure: this is a self-submission; I maintain the listed project.