### PR TITLE
Add Graded (graded.sh) to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Graded](https://graded.sh) - Quality-graded index of 2,000+ x402 services, each probed every 6h and scored A-F on whether an agent can actually pay it and parse the result. Includes a gateway: one API key, prepaid credits (USDC on Base or card), call any passing service through a single endpoint; remote MCP server at `https://graded.sh/mcp` (official registry: `sh.graded/graded-x402`).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds [Graded](https://graded.sh) to the Ecosystem section.

Graded maintains a quality-graded index of 2,000+ x402 services — every service probed every 6 hours and scored A–F on whether an agent can actually pay it and parse the result (grade breakdowns are public per service). It also operates a gateway: one API key with prepaid credits (USDC on Base or card), calling any passing service through a single endpoint, with a remote MCP server at `https://graded.sh/mcp` (official MCP registry: `sh.graded/graded-x402`).

Methodology: https://graded.sh/methodology · agent guide: https://graded.sh/agents

Disclosure: I operate graded.sh. Entry follows the existing one-line format; placed at the end of the Ecosystem section.