### PR TITLE
Add ArisPay Facilitator to Facilitators & Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [thirdweb Facilitator & Supported Networks](https://portal.thirdweb.com/payments/x402/facilitator)
 - [Corbits Faremeter Facilitators & Supported Networks](https://docs.corbits.dev/about-corbits/networks)
 - [OpenZeppelin Relayer x402 Facilitator](https://docs.openzeppelin.com/relayer/guides/stellar-x402-facilitator-guide) - Stellar x402 facilitator plugin for payment verification and settlement via OpenZeppelin Relayer.
+- [ArisPay Facilitator & Supported Networks](https://facilitator.arispay.app/supported) - Free, public x402 facilitator for Base mainnet with USDC and EURC settlement; open /verify and /settle, no API key required.
 
 
 ### Open Source & SDKs


### PR DESCRIPTION
Adds ArisPay Facilitator to Facilitators & Networks, matching the section's name-and-supported-networks style. Factual copy only — verifiable in-band at `GET /supported` (Base mainnet `eip155:8453`, USDC + EURC, EIP-3009, machine-readable no-fee policy) and `GET /facilitator` (discovery); account-free observability at `/status`, `/metrics`, `/trust`, `/receipts/{txHash}`.
