### PR TITLE
Add InsumerAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [InsumerAPI](https://insumermodel.com/ai-agent-verification-api/) - Signed on-chain condition checks for AI agents: token balances, NFT ownership, EAS attestations, and agent standing (ERC-8004 registration, ERC-7710 delegation validity) across 38 chains. Pay per call over x402 (USDC on Base via CDP facilitator, no API key); every answer is an ECDSA-signed boolean, verifiable offline via JWKS. ([Discovery](https://insumermodel.com/.well-known/x402) | [OpenAPI](https://api.insumermodel.com/openapi.json) | [llms.txt](https://insumermodel.com/llms.txt))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds InsumerAPI: signed on-chain condition checks for AI agents (token balances, NFT ownership, EAS attestations, and agent standing via ERC-8004 and ERC-7710) across 38 chains, payable per call over x402 in USDC on Base with no API key. Live discovery: https://insumermodel.com/.well-known/x402

🤖 Generated with [Claude Code](https://claude.com/claude-code)