### PR TITLE
Add Agent-Directed Manipulation (definition + conformance suite) to Security & Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 FAQ – Security](https://docs.cdp.coinbase.com/x402/support/faq#security)
 - [Compliance-Aware Agentic Payments on Stablecoin Rails](https://arxiv.org/abs/2605.00071) - Research paper on policy and compliance guardrails for x402-style stablecoin payment authorization.
+- [Agent-Directed Manipulation](https://github.com/perpensum/agent-directed-manipulation) - Open definition of web page text placed to steer an AI reader's judgment, separated from legitimate machine-readable self-presentation. Two mechanically decidable axes (region, visibility), 18 conformance cases of which 13 expect no finding, and a dependency-free reference implementation. Relevant to agent purchasing flows because a merchant page can be manipulated regardless of how the payment itself is authorized. CC BY 4.0.
 
 ### Benchmarks & Analysis
 - [Dev.to – x402 vs Traditional Payments (Micropayments)](https://dev.to/pathak_prakarsh/x402-finally-payments-built-for-the-internet-not-bolted-onto-it-1058)


### PR DESCRIPTION
Adds one line to **Security & Ops**.

## Why it belongs here

x402 and the surrounding work answer *whether a payment was authorized*. This is a definition for a different question in the same flow: **whether the page the agent read was telling it the truth.**

A merchant page can carry text that is invisible to humans, or planted in a review section by a third party, instructing the reading agent to rank that seller first. **The payment authorization is untouched by this** — the mandate is valid, the signature checks out, the flow completes. The agent simply bought the wrong thing.

So the entry sits alongside the compliance-guardrails paper already in this section: both cover the part of agentic commerce that authorization alone does not reach.

## What it is

- Two mechanically decidable axes — region (first-party / third-party) and visibility (visible / hidden) — and **no subjective axis**, so independent implementations reach the same verdict on the same page
- **23 conformance cases, 18 of which expect no finding.** What it refuses to flag is more of its substance than what it flags; for this kind of judgement false positives are the only fatal failure
- A dependency-free reference implementation: `curl -s https://example.com | node reference/scan.mjs`
- Stated limits rather than a blanket claim of detection: external CSS is not fetched, runtime JavaScript is not evaluated, region detection is inference, and only English and Japanese are in scope
- CC BY 4.0 for the definition, MIT for the code

## Two caveats you should weigh

1. **It is not x402-specific.** If this list is meant to stay strictly within the x402 ecosystem, please close this — I would rather the list keep its focus than have my link in it.
2. **Disclosure:** I am the author. Perpensum is building third-party evaluation of AI agent purchasing decisions, so I have a commercial interest in the definition being adopted. There is no paid product, and implementing it requires no permission, notification, or certification from anyone.