### PR TITLE
Add x402 Utility APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [x402 Utility APIs](https://x402-qr-api.vercel.app) – 8 pay-per-call utility endpoints for agents on Base mainnet via the CDP facilitator: QR code generation, URL-to-clean-Markdown extraction, hashing, DNS lookup, HTTP header inspection, TLS certificate inspection, JSON/YAML/CSV conversion, and text statistics. $0.001–$0.01 USDC per call, no API keys.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds a small suite of 8 pay-per-call utility endpoints to Example Apps.

- Live on Base mainnet via the Coinbase CDP facilitator
- QR generation, clean-Markdown extraction, hashing, DNS, HTTP headers, TLS inspection, JSON/YAML/CSV conversion, text stats
- $0.001-$0.01 USDC per call, no API keys/signup