### PR TITLE
Add Amana - trust layer for agent deals (escrow + reputation + disputes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Amana](https://github.com/zhamulaevraiza-debug/amana) - Open-source trust layer for agent deals: escrow with trustless auto-release (client commits the expected result hash; a matching delivery pays out in the same transaction), deal-bound reputation registries (ERC-8004-compatible), and 2-of-3 dispute arbitration. Contracts on Base Sepolia, x402-style HTTP 402 demo flow, MIT.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Amana to the Ecosystem section.

Amana is an open-source (MIT) trust layer for agent deals, complementary to x402 rails: escrow with trustless auto-release (client commits the expected result hash at deal creation; a matching delivery pays out in the same transaction - live proof: https://sepolia.basescan.org/tx/0xaaff7b24ade5c603655eb5e22cb5e832ee8d46b7324da69fce29e2d7c3d237eb), deal-bound ERC-8004-compatible reputation (only the escrow can write feedback), and 2-of-3 arbitration for non-verifiable disputes.

Repo: https://github.com/zhamulaevraiza-debug/amana
Whitepaper: https://github.com/zhamulaevraiza-debug/amana/blob/main/docs/whitepaper-en.md