### PR TITLE
Add Attest402 — signed evidence packages for web/API responses (x402 service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Cloudflare Announcement of the x402 Foundation](https://blog.cloudflare.com/x402/)
 
 ### Ecosystem
+- [Attest402](https://attest402.com) — Pay-per-call web notarization for agents: cryptographically signed, RFC-3161 timestamped evidence packages of public HTTP responses, verifiable offline. x402 / USDC on Base.
 - [x402Scan](https://x402scan.com/) - Analytics and overview of the x402 ecosystem.
 - [AgentZone](https://agentzone.fun/) - Unified explorer for trustless AI agents, combining ERC-8004 identity, x402 payment history, reputation signals, and live service status across Base and Arbitrum.
 - [AgentStatus](https://github.com/EvanRMora/agentstatus) - Heartbeat and cron monitoring API for AI agents with x402 micropayments, MCP tools, and multi-channel alerts.


### PR DESCRIPTION
Adds Attest402 (https://attest402.com) to the Ecosystem section.

Attest402 is an x402-paid attestation service for agents: POST a public HTTPS URL, pay 0.20 USDC (exact scheme, Base), and receive a portable evidence package — Ed25519-signed canonical record, RFC-3161 trusted timestamp, raw response bytes — that verifies fully offline. Verification API is free, no accounts. Agent-native: llms.txt, OpenAPI, /.well-known/x402.json, Bazaar discovery extension, MCP server.