### PR TITLE
Add agent-tools.net to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [agent-tools.net](https://agent-tools.net) - Pay-per-call API marketplace for AI agents: page-to-Markdown and page-metadata extraction ($0.001-$0.005/call), plus a directory where anyone can list their own agent-facing tool for a flat x402 fee. No accounts, no API keys, no subscriptions; live on Base mainnet USDC.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds agent-tools.net — a pay-per-call x402 API marketplace for AI agents (page-to-Markdown extraction, page metadata extraction, and a directory where third parties can list their own agent-facing tool for a flat x402 fee). Live on Base mainnet USDC.

Site: https://agent-tools.net