### PR TITLE
Add OyaPicks to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
-
+- [OyaPicks](https://oyapicks.app) - Cross-venue prediction market data for AI agents on Base and Algorand. 10 pay-per-call endpoints covering market search, probability movers, volume spikes, cross-venue arbitrage gaps, resolutions, and price history across Polymarket and Alpha Arcade. $0.01-$0.25 USDC per call, no API keys. Backed by a public verifiable prediction-market track record. ([OpenAPI](https://oyapicks.app/openapi.json) | [Discovery](https://oyapicks.app/.well-known/x402) | [Track record](https://oyapicks.app/track))
 
 ### Security & Ops
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)


### PR DESCRIPTION
Live x402 prediction market data API, 10 endpoints on Base and Algorand. Adding under Example Apps alongside the other pay-per-call services.