### PR TITLE
Add Mossgate Trust API and Rue Render API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [Mossgate Trust API](https://api.mossgate.dev) - Onchain risk checks for Base ERC-20 tokens and wallets over x402 (USDC on Base). Returns ok/caution/danger token verdicts (liquidity, pair age, contract flags) and wallet reputation. ([docs](https://api.mossgate.dev/llms.txt))
+- [Rue Render API](https://rue.mossgate.dev) - Renders a URL or raw HTML to PDF, PNG, or JPEG via headless Chromium over x402 (USDC on Base). SSRF-guarded, pure compute.
 
 
 ### Security & Ops


### PR DESCRIPTION
adds two live, x402 v2 paid apis (usdc on base) to the example apps section:

- **mossgate trust api** (https://api.mossgate.dev) - onchain risk checks for base erc-20 tokens and wallets. returns ok/caution/danger token verdicts (liquidity, pair age, contract flags) and wallet reputation. discovery at `/.well-known/x402`, docs at `/llms.txt`.
- **rue render api** (https://rue.mossgate.dev) - renders a url or raw html to pdf/png/jpeg via headless chromium, ssrf-guarded. discovery at `/.well-known/x402`.

both are live and return a valid http 402 challenge before payment. grouped under the existing example apps section next to the other live x402 apis. one factual line each, no hype.
