### PR TITLE
Add PermitVerdict to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [PermitVerdict](https://permitverdict.com?r=agentic-commerce) - US building-permit data API for AI agents. Free metro/trade lead previews (counts + 5-row sample) and free address permit-history lookups, no signup. Full datasets and CSV export paid per call via x402 (USDC on Base). [MCP server](https://permitverdict.com/mcp?r=agentic-commerce) available.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds PermitVerdict — a pay-per-call x402 data API for US building-permit
activity (metro/trade lead previews, address permit history), with an
MCP server wrapper for direct agent use.

Disclosure: I run this service. Free preview endpoints are unmetered
and require no API key; full data/exports are paid via x402. Placed
under Ecosystem alongside the other data-API entries (Strale, AgentStatus) —
open to a different section if you'd place it elsewhere.