### PR TITLE
Add QuickSilver Pro to Ecosystem (x402 LLM inference top-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [QuickSilver Pro](https://quicksilverpro.io/docs/x402/) - x402-paid top-up for OpenAI-compatible LLM inference on Base mainnet. Pay a fixed USDC denomination to `/x402/topup/{1,5,10}` via the Coinbase CDP facilitator and receive a prepaid, OpenAI-compatible API key — no account, no card; the key meters per-token against the prepaid balance. ([Docs](https://quicksilverpro.io/docs/x402/))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **QuickSilver Pro** under Ecosystem. x402-paid top-up for OpenAI-compatible LLM inference on Base mainnet (Coinbase CDP facilitator): pay a fixed USDC denomination, receive a prepaid OpenAI-compatible API key — no account, no card. Live: https://quicksilverpro.io/docs/x402/