### PR TITLE
Add Israel Tariff x402 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Israel Tariff x402 API](https://github.com/HassanEwida/israel-tariff-x402) - Pay-per-call access to normalized Israeli customs tariff data from the official Israel Tax Authority open dataset. Base mainnet, 0.0025 USDC per successful lookup. [Live endpoint](https://israel-tariff-x402.onrender.com/il/tariff/:code)
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Israel Tariff x402 API, a Base mainnet x402 endpoint providing normalized Israeli customs tariff data sourced from the official Israel Tax Authority open dataset.

Repository:
https://github.com/HassanEwida/israel-tariff-x402

Live endpoint:
https://israel-tariff-x402.onrender.com/il/tariff/:code

Price:
0.0025 USDC per successful lookup