### PR TITLE
Add BlinkCodes to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [BlinkCodes](https://blinkcodes.com) – Production storefront selling real-world digital goods to agents via x402: gift card codes (Steam, Razer Gold, PSN, Apple), game top-ups, and travel eSIMs. Single-call purchase: `POST /api/v1/buy` answers 402 priced for the chosen catalog item, replay with `X-PAYMENT` delivers the code (USDC on Base via the CDP facilitator). 1200+ item catalog, [agent docs](https://blinkcodes.com/llms.txt), MCP + A2A discovery endpoints.
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds [BlinkCodes](https://blinkcodes.com) — a production x402 storefront selling real-world digital goods (gift card codes, game top-ups, travel eSIMs) to agents.

- Paywall: `POST /api/v1/buy` — 402 priced per catalog item, replay with `X-PAYMENT` delivers the code. USDC on Base via the CDP facilitator.
- Free rail description: `GET https://blinkcodes.com/api/v1`
- Agent docs: https://blinkcodes.com/llms.txt · OpenAPI with `x-payment-info`: https://blinkcodes.com/openapi.json
- Also exposes read-only MCP (`/mcp`) + A2A (`/.well-known/agent-card.json`) for catalog discovery.

Verified live: settled on-chain settlement on Base delivering a Steam code end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)