### PR TITLE
Add Agentable — agent-readiness auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Agentable](https://seo4agent.com/audit/run) - Agent-readiness auditor for websites. Checks if your site is discoverable and usable by AI agents (L0–L5 framework). $0.10 USDC per audit on Base mainnet via x402. ([GitHub](https://github.com/varustamov/agentable-core))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Add Agentable (https://seo4agent.com) — agent-readiness auditor for websites.

Checks if a site is discoverable and usable by AI agents using the L0–L5 framework. $0.10 USDC per audit on Base mainnet via x402 protocol. No API key required.

GitHub: https://github.com/varustamov/agentable-core