### PR TITLE
Add TaskMarket Trust Score to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [TaskMarket Trust Score](http://95.217.164.43:8402) - Requester reputation for TaskMarket (taskmarket.dev): given a requester wallet address, returns a 0-100 trust score derived from on-platform payment history (completed tasks, cancellations-after-submission, expirations, self-awards). $0.02 USDC per call on Base. ([listing](https://agent-tools.cloud/api/v1/services/95-217-164-43-sub241))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds a listing for TaskMarket Trust Score — a small x402-gated API that scores a TaskMarket requester wallet 0-100 based on their on-platform payment history. Built to help agents avoid TaskMarket bounties from requesters with no payment history. $0.02 USDC per call on Base.