### PR TITLE
Add AgentFund US Economic, SEC EDGAR & On-Chain Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AgentFund US Economic, SEC & On-Chain Data](https://x402.agentfund.net) - 21 pay-per-call tools over free public data: US macro indicators (Treasury yield curve, BLS CPI, jobs, PCE, GDP, retail sales, housing starts, EIA energy, release calendar), SEC EDGAR filings (insider Form 4, XBRL financials, 13F holdings, filing feeds, full-text search), and on-chain EVM reads (token balances, portfolios, cross-chain balances, Chainlink oracle prices, gas). OpenAPI discovery at `/openapi.json`, also callable over MCP at `/mcp`. USDC on Base.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds a live x402 service to the Ecosystem section.

**What it is:** 21 pay-per-call tools for agents, settled in USDC on Base via the Coinbase CDP facilitator.

- **US macro** — Treasury yield curve, BLS CPI, jobs, PCE, GDP, retail sales, housing starts, EIA energy, release calendar
- **SEC EDGAR** — insider Form 4, XBRL financials, 13F holdings, filing feeds, full-text search
- **On-chain EVM** — token balances, portfolios, cross-chain balances, Chainlink oracle prices, gas

Every source is free public-domain US government data or a direct on-chain read, so there is no upstream vendor licence to lapse.

**Verification**
- All 21 resources return `valid: true` from CDP's x402 validator (25/25 preflight checks)
- OpenAPI 3.1 discovery at https://x402.agentfund.net/openapi.json with `x-payment-info` per route
- Real payment settled on Base mainnet
- Also listed on x402scan, and in the Official MCP Registry as `net.agentfund/us-economic-macro-sec-edgar-onchain-data`
- Same tools callable over MCP at `/mcp`

Grouped under the existing Ecosystem section per the contributing guidance.