### PR TITLE
Add x402 Weather Server to Example Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
+- [x402 Weather Server](https://x402-seller-server.vercel.app) - Next.js x402 seller reference reselling live weather (Open-Meteo, no API key) behind a $0.001 USDC paywall on Base + Solana. Demonstrates `withX402` with Bazaar discovery + offer-receipt extensions, per-city results, and pay-only-on-success settlement (a failed lookup never charges the buyer).
 
 
 ### Security & Ops


### PR DESCRIPTION
Adds a Next.js x402 seller reference (weather resale demo) to the Example Apps section, alongside agent-marketplace-proxy. Demonstrates withX402 with Bazaar discovery + offer-receipt extensions, real live per-city data from Open-Meteo, and pay-only-on-success settlement.