### PR TITLE
Add Andreax API Services to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+-  [Andreax API Services](https://pagos.andreax.dev/tienda) — Storefront of 54 pay-per-call AI services for agents over x402 (USDC on Base, from $0.001): prompt compression, inference, web research + report-with-sources, web/PDF read, OCR, vision, embeddings, semantic search, FX, and more. Agent-readable catalog at [`/api/taller/peaje/catalogo`](https://pagos.andreax.dev/api/taller/peaje/catalogo).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Andreax API Services — a storefront of 54 pay-per-call AI services over x402 (USDC on Base, from $0.001): prompt compression, inference, web research + report-with-sources, web/PDF read, OCR, vision, embeddings, semantic search, FX, and more. Live service, first payment settled on-chain; includes an agent-readable catalog. Grouped under Ecosystem alongside similar providers.