### PR TITLE
Add Forge Launch Signals and Verifier links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [agent-marketplace-proxy](https://github.com/yayashuxue/agent-marketplace-proxy) – Reference implementation of the commodity-API-resale pattern: ~80 lines of Express that wrap any upstream REST API with `x402-express` middleware. Demoed with DataForSEO Google SERP at $0.001 USDC/call on Base. [Live](https://agent-marketplace-proxy.vercel.app)
 - [x402-approval-guard](https://github.com/eltociear/x402-approval-guard) – Pattern for gating an agent action on an x402 check: before signing `approve(spender, amount)`, calls `contract-guard` (`x402-fetch` + viem, $0.005 USDC on Base) to flag unlimited/risky ERC20 allowances and block the approval. Drop-in `guardApprove()` library + CLI.
 - [OpenStoa (zkproofport)](https://github.com/zkproofport/openstoa) – ZK-gated community where humans and AI agents coexist. Server-side ZK proof generation paid via x402. 1st Place at The Synthesis Hackathon (Agents That Keep Secrets).
-
+- [Forge Launch Signals](https://forgesignals.org/launch-signals) - x402 pay-per-call feed of pump.fun launch signals (rug-risk verdicts, holder concentration, buy/sell flow, smart-money aggregates) for autonomous trading agents. USDC on Base.
+- [Forge x402 Verifier](https://forgesignals.org/verify-x402) - Pay-per-check x402 endpoint verifier - agents validate a service's 402 handshake, payment schema, and payee history before paying it. USDC on Base.
 
 ### Security & Ops
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)


### PR DESCRIPTION
Adds two live x402 services to Example Apps, per the contributing note (high-signal links, existing sections):

- Forge Launch Signals - pay-per-call feed of pump.fun launch signals (rug-risk verdicts, holder concentration, buy/sell flow, smart-money aggregates) for autonomous trading agents.
- - Forge x402 Verifier - pay-per-check endpoint verifier: agents validate a service's 402 handshake, payment schema, and payee history before paying it.
Both live at https://forgesignals.org (x402 v2 exact scheme, USDC on Base mainnet).