### PR TITLE
Add AOTrust Protocol — verifiable execution receipts for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Solana Foundation Pay (x402/MPP CLI and MCP)](https://github.com/solana-foundation/pay) - Local payment layer for handling x402 payment challenges with wallet-authorized stablecoin signing.
 - [Pipegate (x402 + Payment Channels)](https://github.com/Dhruv-2003/pipegate)
 - [TrustBench](https://trustbench.io) - Non-custodial routing and audit layer on top of x402. Ed25519-signed receipts with on-chain settlement evidence, verifiable offline. Fail-safe paywall on Base via the Coinbase CDP facilitator. Verifier on npm: [`@trustbench/verify-receipt`](https://www.npmjs.com/package/@trustbench/verify-receipt).
+- [AOTrust Protocol](https://github.com/GitSerge-crypto/aotrust-skills) - x402-native verifiable execution receipts and proof of existence for autonomous AI agents on Base. Ed25519-signed PDRs, NEAR Merkle anchoring, free tier. Python SDK + LangChain/CrewAI tool.
 - [thirdweb/x402 (Github)](https://github.com/thirdweb-dev/js/tree/main/packages/thirdweb/src/x402)
 - [Faremeter (Typescript Facilitator, Middleware, and Examples)](https://github.com/faremeter/faremeter)
 - [x402-dotnet (Community)](https://github.com/michielpost/x402-dotnet)


### PR DESCRIPTION
## What

[AOTrust Protocol](https://github.com/GitSerge-crypto/aotrust-skills) is an x402-native proof of existence and verifiable execution receipt layer for autonomous AI agents.

## Why

- **x402-native** — /usr/bin/bash.01 USDC on Base per PDR (Provenance Data Record)
- **Ed25519-signed** — NEP-413 compliant, offline-verifiable
- **NEAR Merkle anchoring** — daily on-chain timestamp
- **Free tier** — no wallet required, 5 PDR/day per IP
- **Python SDK** — `pip install aotrust-protocol` + LangChain/CrewAI AOTrustTool
- **GitHub Action** — `uses: GitSerge-crypto/aotrust-skills/action@v1`
- **MCP server** — `api.aotrust.link/mcp` (Glama + Smithery registered)

## Category

Open Source & SDKs — verification, evidence, and trust for agentic commerce.

## Links

- GitHub: https://github.com/GitSerge-crypto/aotrust-skills
- PyPI: https://pypi.org/project/aotrust-protocol/
- Web: https://shield.aotrust.link
- Verify: https://verify.aotrust.link