### PR TITLE
Add Prism Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Prism Network](https://prismnetwork.tech) - GPU compute network on Robinhood Chain where agents rent machines and buy LLM generations over x402 in USDG. Per-second lease billing with on-chain settlement receipts; inference priced per request by model and output cap. ([MCP server](https://www.npmjs.com/package/@prismnetwork/mcp)) ([Manifest](https://api.prismnetwork.tech/.well-known/x402.json))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Prism Network to Ecosystem: a GPU compute network on Robinhood Chain where agents rent machines and buy LLM generations over x402 in USDG, with per-second billing and on-chain settlement receipts.