### PR TITLE
Add AgenticSettle to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [AgenticSettle](https://agenticsettle.io) - AI-judge verification layer for agent-generated work, gating x402 settlement release on an objective 0-100 VOP score (PASS/PARTIAL/FAIL). Free MCP server for the verification-only slice ([GitHub](https://github.com/agenticsettleio/agenticsettle-mcp), MIT). Verify → on-chain anchor → x402 settlement loop live-verified end-to-end on Base Sepolia (testnet); minimal reference integration at [agenticsettle-x402-demo](https://github.com/agenticsettleio/agenticsettle-x402-demo).
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
AI-judge verification layer that gates x402 settlement on an objective VOP score (PASS/PARTIAL/FAIL) — most entries in this list are payment/wallet/routing infra; this sits one layer up, deciding *whether and how much* to settle based on whether the agent's output actually met the buyer's criteria.

- Free MCP server (verification-only slice, MIT): https://github.com/agenticsettleio/agenticsettle-mcp
- Minimal x402 reference demo (verify → anchor → settle, live on Base Sepolia testnet): https://github.com/agenticsettleio/agenticsettle-x402-demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)