### PR TITLE
Add What Agents Buy (independent x402 API reviews) to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [What Agents Buy](https://whatagentsbuy.com) - Independent, measured reviews of x402 API sellers: pre-payment CLEAR/HOLD/ABORT verdicts (live price and payTo honesty vs the listing, phantom paywalls, delivery receipts), accuracy grades from real purchases checked against a primary source, and on-chain settlement data. Nothing sponsored, no service pays to appear. [MCP server](https://whatagentsbuy.com/mcp) in the official registry as `com.whatagentsbuy/whatagentsbuy`.
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds **What Agents Buy** (https://whatagentsbuy.com) to the Ecosystem section, alongside the other analytics/directory tools (x402Scan, x402station, Onyx Bazaar).

It is an independent, measured review layer for x402 API sellers: pre-payment CLEAR/HOLD/ABORT verdicts (live price and payTo honesty vs the listing, phantom paywalls, delivery receipts), accuracy grades from real purchases checked against a primary source, and on-chain settlement data. Nothing is sponsored. Remote MCP at https://whatagentsbuy.com/mcp, in the official MCP Registry as `com.whatagentsbuy/whatagentsbuy`.