### PR TITLE
Add Agent Tolls to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Agent Tolls](https://agent-toll.com) - Toll gate for websites: AI agents pay a per-page USDC toll via x402 (Base and Solana quoted in one 402), human visitors pass free. DNS-level install on any site, per-path prices, 85% of every toll to the owner through an immutable on-chain split. ([Annotated 402 response](https://agent-toll.com/docs))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adding [Agent Tolls](https://agent-toll.com) under Ecosystem — a production toll gate for websites on Base and Solana mainnet: gated pages answer AI agents with HTTP 402 carrying x402 v2 terms (both chains in one quote); agents pay a per-page USDC toll from their own wallet, humans pass free. Owners install at the DNS level, set per-path prices, and keep 85% via an immutable on-chain split.

Primary-source verifiable without a wallet: `curl -i https://edge.agent-toll.com/report` returns the live 402; the response is annotated field by field at https://agent-toll.com/docs.