### PR TITLE
Add Frantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [Strale](https://strale.dev) - Business data & compliance APIs for AI agents. 250+ quality-scored capabilities (company data, VAT validation, sanctions screening, KYB) across 27 countries with x402 payment support. [MCP server](https://www.npmjs.com/package/strale-mcp) available.
 - [Hedera and the x402 Payment Standard](https://hedera.com/blog/hedera-and-the-x402-payment-standard/) - Hedera ecosystem overview of x402-style programmable payments for applications and AI agents.
 - [CardZero](https://cardzero.ai) - Smart-contract wallet (ERC-4337) for AI agents on Base mainnet, USDC. Buyer-side x402 support via `POST /v1/x402/pay`. Owner-controlled spending rules (per-tx limit, daily cap, whitelist, freeze) enforced on-chain. Also runs first known production deployment of ERC-8004 + ERC-8183.
+- [Frantic](https://gofrantic.com) - Bounty board where AI agents claim funded work, deliver artifacts in the open, and are paid in USDC on Base only when a delivery is accepted, with every claim, judgment, and payout sealed to a public receipt ledger. Vendors post and fund work over x402 from $2.00 at `POST /v1/vendor-postings/x402`. ([Discovery](https://gofrantic.com/.well-known/x402) | [MCP](https://api.gofrantic.com/mcp))
 
 ### Facilitators & Networks
 - [Coinbase Hosted Facilitator (Base)](https://docs.cdp.coinbase.com/x402#offload-your-infra)


### PR DESCRIPTION
Adds Frantic to the Ecosystem section.

Frantic is a bounty board where AI agents claim funded work, deliver artifacts in the open, and are paid in USDC on Base only when a delivery is accepted. Every claim, judgment, and payout is sealed to a public receipt ledger.

The x402 surface is the demand side: a vendor posts a task and funds it in one call at `POST https://gofrantic.com/v1/vendor-postings/x402`, from $2.00 USDC on Base mainnet. An unpaid GET or POST returns the full x402 v2 challenge with payment requirements and the input schema:

```
curl -s https://gofrantic.com/v1/vendor-postings/x402
```

Discovery at https://gofrantic.com/.well-known/x402 and https://gofrantic.com/openapi.json. Indexed in the CDP Bazaar, and registered on x402scan and 402index.