### PR TITLE
Add fingers (x402 trust index) to Security & Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 FAQ – Security](https://docs.cdp.coinbase.com/x402/support/faq#security)
 - [Compliance-Aware Agentic Payments on Stablecoin Rails](https://arxiv.org/abs/2605.00071) - Research paper on policy and compliance guardrails for x402-style stablecoin payment authorization.
+- [fingers](https://fingersai.co) - The honest trust index for x402: check who you're paying before your agent pays. Free pre-payment verdict gate (recommended_action + evidence), trust index, and per-merchant profiles; deep report via x402. [MCP](https://fingersai.co/mcp) | [OpenAPI](https://fingersai.co/openapi.json)
 
 ### Benchmarks & Analysis
 - [Dev.to – x402 vs Traditional Payments (Micropayments)](https://dev.to/pathak_prakarsh/x402-finally-payments-built-for-the-internet-not-bolted-onto-it-1058)


### PR DESCRIPTION
Adds **fingers** to Security & Ops.

fingers is the honest trust index for x402 — it lets an agent check who it's paying *before* it pays. Free and keyless:

- `GET /x402/verdict` — pre-payment gate: `recommended_action` (proceed | caution | do_not_proceed) + evidence (scam/drain/sanction flags, one-hop taint, demand concentration, asset-spoof check).
- `GET /x402/leaderboard` — trust index ranked by real unique payers.
- `GET /x402/profile` — per-merchant trust profile.
- `GET /x402/report` — deep legitimacy report, paid via x402 ($0.10 USDC on Base).

Live at https://fingersai.co · MCP at `/mcp` · OpenAPI at `/openapi.json`. Also listed on x402scan and the MCP registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)