### PR TITLE
Add fingers to Security & Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ x402 is an emerging open standard from the Coinbase ecosystem focused on safer, 
 - [x402 Whitepaper – Security Section](https://www.x402.org/x402-whitepaper.pdf)
 - [x402 FAQ – Security](https://docs.cdp.coinbase.com/x402/support/faq#security)
 - [Compliance-Aware Agentic Payments on Stablecoin Rails](https://arxiv.org/abs/2605.00071) - Research paper on policy and compliance guardrails for x402-style stablecoin payment authorization.
+- [fingers](https://fingersai.co) - The honest trust index for x402. Check who you're paying before your agent pays. A free pre-payment gate returns proceed / caution / do_not_proceed with the evidence behind it (scam and drain flags, one-hop taint, demand concentration, asset check), plus a trust index ranked by real payers and per-merchant profiles. Deep report available via x402. [MCP](https://fingersai.co/mcp) | [OpenAPI](https://fingersai.co/openapi.json)
 
 ### Benchmarks & Analysis
 - [Dev.to – x402 vs Traditional Payments (Micropayments)](https://dev.to/pathak_prakarsh/x402-finally-payments-built-for-the-internet-not-bolted-onto-it-1058)


### PR DESCRIPTION
fingers is a trust index for x402. It lets an agent check who it's paying before it pays.

Free and keyless:
- `GET /x402/verdict` returns proceed / caution / do_not_proceed with the evidence (scam, drain, and sanction flags, one-hop taint, demand concentration, asset check)
- `GET /x402/leaderboard` ranks merchants by real unique payers
- `GET /x402/profile` is a per-merchant trust profile
- `GET /x402/report` is a deep report, paid via x402 (0.10 USDC on Base)

Live at https://fingersai.co. Also listed on x402scan and the MCP registry.
